### PR TITLE
feat: add support for aborting running query

### DIFF
--- a/tui/bubbles/help/help.go
+++ b/tui/bubbles/help/help.go
@@ -37,6 +37,8 @@ func (b Bubble) collectHelpBindings() []key.Binding {
 	switch b.state {
 	case state.Query:
 		bindings = append(bindings, k.submit, k.section, k.copyQuery, k.save)
+	case state.Running:
+		bindings = append(bindings, k.abort)
 	case state.Input, state.Output:
 		bindings = append(bindings, k.section, k.navigate, k.page, k.copyQuery, k.save)
 	case state.Save:

--- a/tui/bubbles/help/keys.go
+++ b/tui/bubbles/help/keys.go
@@ -6,6 +6,7 @@ type keyMap struct {
 	section   key.Binding
 	back      key.Binding
 	submit    key.Binding
+	abort     key.Binding
 	navigate  key.Binding
 	page      key.Binding
 	save      key.Binding
@@ -22,6 +23,9 @@ var keys = keyMap{
 	submit: key.NewBinding(
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "submit query")),
+	abort: key.NewBinding(
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "abort running query")),
 	navigate: key.NewBinding(
 		key.WithKeys("↑↓"),
 		key.WithHelp("↑↓", "scroll")),

--- a/tui/bubbles/jqplayground/commands.go
+++ b/tui/bubbles/jqplayground/commands.go
@@ -1,6 +1,7 @@
 package jqplayground
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -28,7 +29,7 @@ type writeToFileMsg struct{}
 
 type copyQueryToClipboardMsg struct{}
 
-func (b *Bubble) executeQuery() tea.Cmd {
+func (b *Bubble) executeQuery(ctx context.Context) tea.Cmd {
 	return func() tea.Msg {
 		query, err := gojq.Parse(b.queryinput.GetInputValue())
 		if err != nil {
@@ -39,7 +40,7 @@ func (b *Bubble) executeQuery() tea.Cmd {
 		var msgTemplate interface{}
 		json.Unmarshal(b.inputdata.GetInputJson(), &msgTemplate)
 		var results strings.Builder
-		iter := query.Run(msgTemplate) // or query.RunWithContext
+		iter := query.RunWithContext(ctx, msgTemplate)
 		for {
 			v, ok := iter.Next()
 			if !ok {

--- a/tui/bubbles/jqplayground/model.go
+++ b/tui/bubbles/jqplayground/model.go
@@ -29,6 +29,7 @@ type Bubble struct {
 	statusbar        statusbar.Bubble
 	fileselector     fileselector.Bubble
 	results          string
+	cancel           func()
 }
 
 func New(inputJson []byte, filename string) Bubble {

--- a/tui/bubbles/state/state.go
+++ b/tui/bubbles/state/state.go
@@ -4,6 +4,7 @@ type State uint
 
 const (
 	Query State = iota
+	Running
 	Input
 	Output
 	Save


### PR DESCRIPTION
I propose to support aborting running query. Executing jq query can stuck with infinite or no output. Consider `range(infinite)` or `def f: f; f`. Currently jqp consumes CPU 100%, and cannot abort the query. I propose to introduce query-running state and allow users to abort the query with <kbd>ctrl+c</kbd>.