### PR TITLE
chore: refactor updating section border colors and help state

### DIFF
--- a/tui/bubbles/jqplayground/util.go
+++ b/tui/bubbles/jqplayground/util.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	"github.com/alecthomas/chroma/quick"
-	"github.com/noahgorstein/jqp/tui/styles"
 	"github.com/noahgorstein/jqp/tui/utils"
 )
 
@@ -28,10 +27,4 @@ func highlightJson(input []byte) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 	quick.Highlight(buf, string(input), "json", "terminal16", utils.GetChromaTheme())
 	return buf
-}
-
-func (b *Bubble) setAllBordersInactive() {
-	b.queryinput.SetBorderColor(styles.GREY)
-	b.inputdata.SetBorderColor(styles.GREY)
-	b.output.SetBorderColor(styles.GREY)
 }


### PR DESCRIPTION
I propose to refactor state updating by moving code for section border colors and help state. By doing this, you'll less likely forget to update them on adding key mappings. What do you think?