### PR TITLE
ui: put space in between input/output on odd terminal width

### DIFF
--- a/tui/bubbles/jqplayground/view.go
+++ b/tui/bubbles/jqplayground/view.go
@@ -6,12 +6,17 @@ import (
 )
 
 func (b Bubble) View() string {
+	inputoutput := []string{b.inputdata.View()}
+	if b.width % 2 != 0 {
+		inputoutput = append(inputoutput, " ")
+	}
+	inputoutput = append(inputoutput, b.output.View())
 
 	if b.state == state.Save {
 		return lipgloss.JoinVertical(
 			lipgloss.Left,
 			b.queryinput.View(),
-			lipgloss.JoinHorizontal(lipgloss.Top, b.inputdata.View(), b.output.View()),
+			lipgloss.JoinHorizontal(lipgloss.Top, inputoutput...),
 			b.fileselector.View(),
 			b.statusbar.View(),
 			b.help.View())
@@ -20,7 +25,7 @@ func (b Bubble) View() string {
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		b.queryinput.View(),
-		lipgloss.JoinHorizontal(lipgloss.Top, b.inputdata.View(), b.output.View()),
+		lipgloss.JoinHorizontal(lipgloss.Top, inputoutput...),
 		b.statusbar.View(),
 		b.help.View())
 }


### PR DESCRIPTION
When the terminal width isn't even, there is a space between the right border of the output box and the end of the terminal, which causes it to not be aligned to the right border of the prompt box.

Add a space in between the input and output boxes to make the border of the output box be aligned to the prompt box.