### PR TITLE
config: option for overrides to chroma styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Flags:
   -v, --version         version for jqp
 ```
 
-`jqp` also supports input from STDIN. 
+`jqp` also supports input from STDIN. STDIN takes precedence over the command line flag.
 
 ```
 ➜ curl "https://api.github.com/repos/stedolan/jq/issues?per_page=2" | jqp 
@@ -97,8 +97,10 @@ If a configuration option is present in both the configuration file and the comm
 ### Available Configuration Options
 
 ```yaml
-theme: "nord" # controls the color scheme
-file: "/path/to/input/file.json" # stdin takes precedence over command line flag and this option
+theme:
+  name: "nord" # controls the color scheme
+  chromaStyleOverrides: # override parts of the chroma style
+    kc: "#009900 underline" # keys use the chroma short names
 ```
 
 ## Themes
@@ -106,10 +108,24 @@ file: "/path/to/input/file.json" # stdin takes precedence over command line flag
 Themes can be specified on the command line via the `-t/--theme <themeName>` flag. You can also set a theme in your [configuration file](#configuration). 
 
 ```yaml
-theme: "monokai"
+theme:
+  name: "monokai"
 ```
 
 <img width="1624" alt="Screen Shot 2022-10-02 at 5 31 40 PM" src="https://user-images.githubusercontent.com/23270779/193477383-db5ca769-12bf-4fd0-b826-b1fd4086eac3.png">
+
+### Chroma Style Overrides
+
+Overrides to the chroma styles used for a theme can be configured in your [configuration file](#configuration). 
+
+For the list of short keys, see [`chroma.StandardTypes`](https://github.com/alecthomas/chroma/blob/d38b87110b078027006bc34aa27a065fa22295a1/types.go#L210-L308). To see which token to use for a value, see the [JSON lexer](https://github.com/alecthomas/chroma/blob/master/lexers/embedded/json.xml) (look for `<token>` tags). To see the color and what's used in the style you're using, look for your style in the chroma [styles directory](https://github.com/alecthomas/chroma/tree/master/styles).
+
+```yaml
+theme:
+  name: "monokai" # name is required to know which theme to override
+  chromaStyleOverrides:
+    kc: "#009900 underline"
+```
 
 Themes are broken up into [light](#light-themes) and [dark](#dark-themes) themes. Light themes work best in terminals with a light background and dark themes work best in a terminal with a dark background. If no theme is specified or a non-existant theme is provided, the default theme is used, which was created to work with both terminals with a light and dark background. 
 

--- a/tui/bubbles/inputdata/inputdata.go
+++ b/tui/bubbles/inputdata/inputdata.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
-	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -34,7 +33,7 @@ func New(inputJson []byte, filename string, theme theme.Theme) Bubble {
 		Styles:          styles,
 		viewport:        v,
 		inputJson:       inputJson,
-		highlightedJson: highlightInputJson(inputJson, *theme.ChromaStyle),
+		highlightedJson: highlightInputJson(inputJson, theme.ChromaStyle),
 		filename:        filename,
 	}
 	return b
@@ -45,7 +44,7 @@ func (b *Bubble) SetBorderColor(color lipgloss.TerminalColor) {
 	b.Styles.infoStyle.BorderForeground(color)
 }
 
-func highlightInputJson(inputJson []byte, chromaStyle chroma.Style) *bytes.Buffer {
+func highlightInputJson(inputJson []byte, chromaStyle *chroma.Style) *bytes.Buffer {
 	var f interface{}
 	// TODO: error handling
 	json.Unmarshal(inputJson, &f)
@@ -55,7 +54,7 @@ func highlightInputJson(inputJson []byte, chromaStyle chroma.Style) *bytes.Buffe
 	json.Indent(&prettyJSON, []byte(inputJson), "", "    ")
 
 	buf := new(bytes.Buffer)
-	quick.Highlight(buf, prettyJSON.String(), "json", utils.GetTerminalColorSupport(), chromaStyle.Name)
+	utils.HighlightJson(buf, prettyJSON.String(), chromaStyle)
 
 	return buf
 }

--- a/tui/bubbles/jqplayground/commands.go
+++ b/tui/bubbles/jqplayground/commands.go
@@ -55,7 +55,7 @@ func (b *Bubble) executeQuery(ctx context.Context) tea.Cmd {
 			results.WriteString(fmt.Sprintf("%s\n", string(r)))
 		}
 
-		highlightedOutput := highlightJson([]byte(results.String()), *b.theme.ChromaStyle)
+		highlightedOutput := highlightJson([]byte(results.String()), b.theme.ChromaStyle)
 		return queryResultMsg{
 			rawResults:         results.String(),
 			highlightedResults: highlightedOutput.String(),

--- a/tui/bubbles/jqplayground/util.go
+++ b/tui/bubbles/jqplayground/util.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	"github.com/alecthomas/chroma/v2"
-	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/noahgorstein/jqp/tui/utils"
 )
 
@@ -14,7 +13,7 @@ func isValidJson(input []byte) bool {
 	return json.Unmarshal(input, &js) == nil
 }
 
-func highlightJson(input []byte, chromaStyle chroma.Style) *bytes.Buffer {
+func highlightJson(input []byte, chromaStyle *chroma.Style) *bytes.Buffer {
 
 	if isValidJson(input) {
 		var f interface{}
@@ -22,10 +21,10 @@ func highlightJson(input []byte, chromaStyle chroma.Style) *bytes.Buffer {
 		var prettyJSON bytes.Buffer
 		json.Indent(&prettyJSON, []byte(input), "", "    ")
 		buf := new(bytes.Buffer)
-		quick.Highlight(buf, prettyJSON.String(), "json", utils.GetTerminalColorSupport(), chromaStyle.Name)
+		utils.HighlightJson(buf, prettyJSON.String(), chromaStyle)
 		return buf
 	}
 	buf := new(bytes.Buffer)
-	quick.Highlight(buf, string(input), "json", utils.GetTerminalColorSupport(), chromaStyle.Name)
+	utils.HighlightJson(buf, string(input), chromaStyle)
 	return buf
 }

--- a/tui/theme/theme.go
+++ b/tui/theme/theme.go
@@ -427,11 +427,12 @@ var themeMap = map[string]Theme{
 	},
 }
 
-func GetTheme(theme string) Theme {
+// returns a theme by name, and true if default theme was returned
+func GetTheme(theme string) (Theme, bool) {
 	lowercasedTheme := strings.ToLower(strings.TrimSpace(theme))
 	if value, ok := themeMap[lowercasedTheme]; ok {
-		return value
+		return value, false
 	} else {
-		return getDefaultTheme()
+		return getDefaultTheme(), true
 	}
 }

--- a/tui/utils/utils.go
+++ b/tui/utils/utils.go
@@ -1,12 +1,41 @@
 package utils
 
 import (
+	"io"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 )
 
+func HighlightJson(w io.Writer, source string, style *chroma.Style) error {
+	l := lexers.Get("json")
+	if l == nil {
+		l = lexers.Fallback
+	}
+	l = chroma.Coalesce(l)
+
+	f := formatters.Get(getTerminalColorSupport())
+	if f == nil {
+		f = formatters.Fallback
+	}
+
+	if style == nil {
+		style = styles.Fallback
+	}
+
+	it, err := l.Tokenise(nil, source)
+	if err != nil {
+		return err
+	}
+	return f.Format(w, style, it)
+}
+
 // returns a string used for chroma syntax highlighting
-func GetTerminalColorSupport() string {
+func getTerminalColorSupport() string {
 	switch lipgloss.ColorProfile() {
 	case termenv.Ascii:
 		return "terminal"


### PR DESCRIPTION
User facing changes:
- Remove file option from config
- Move theme option to theme.name
- Add theme.chromaStyleOverrides map for style overrides

Code changes:
- Copy code from quick.Highlight to use chroma.Style object instead of looking up by name
- Pass chroma.Style pointer instead of object as chroma Format requires style pointer

Fix: #27 
Fix: #30 