### PR TITLE
feat: add basic command history

### DIFF
--- a/tui/bubbles/jqplayground/update.go
+++ b/tui/bubbles/jqplayground/update.go
@@ -90,6 +90,7 @@ func (b Bubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd = b.writeOutputToFile()
 				cmds = append(cmds, cmd)
 			} else if b.state == state.Query {
+				b.queryinput.RotateHistory()
 				b.state = state.Running
 				var ctx context.Context
 				ctx, b.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
Related to #11

A really basic command history. Features:

- On enter the history is rotated.
- On up arrow press the user navigates in history backward (towards latest).
- On down arrow press the user navigates in history forward (towards newest).

More complex behaviour (e.g. history suggestion with tab trigger) could be added by replacing `textinput.Model` of `queryinput.Bubble` with a fully custom model.