### PR TITLE
Add arch linux installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ brew install noahgorstein/tap/jqp
 sudo port install jqp
 ```
 
+### Arch Linux
+Available through the Arch User Repository as [jqp-bin](https://aur.archlinux.org/packages/jqp-bin).
+```bash
+yay -S jqp-bin
+```
+
 ### Github releases
 
 Download the relevant asset for your operating system from the latest Github release. Unpack it, then move the binary to somewhere accessible in your `PATH`, e.g. `mv ./jqp /usr/local/bin`.


### PR DESCRIPTION
I packaged your tool for the Arch User Repository. This adds the installation instructions to the README.

See https://aur.archlinux.org/packages/jqp-bin