### PR TITLE
update chroma and add catppuccin color themes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/noahgorstein/jqp
 go 1.21
 
 require (
-	github.com/alecthomas/chroma/v2 v2.3.0
+	github.com/alecthomas/chroma/v2 v2.12.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.1
@@ -17,7 +17,7 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
-	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,12 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/alecthomas/chroma/v2 v2.3.0 h1:83xfxrnjv8eK+Cf8qZDzNo3PPF9IbTWHs7z28GY6D0U=
-github.com/alecthomas/chroma/v2 v2.3.0/go.mod h1:mZxeWZlxP2Dy+/8cBob2PYd8O2DwNAzave5AY7A2eQw=
-github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
-github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
+github.com/alecthomas/assert/v2 v2.2.1/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
+github.com/alecthomas/chroma/v2 v2.12.0 h1:Wh8qLEgMMsN7mgyG8/qIpegky2Hvzr4By6gEF7cmWgw=
+github.com/alecthomas/chroma/v2 v2.12.0/go.mod h1:4TQu7gdfuPjSh76j78ietmqh9LiurGF0EpseFXdKMBw=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
+github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -66,8 +68,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
-github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -141,6 +143,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/tui/theme/theme.go
+++ b/tui/theme/theme.go
@@ -71,7 +71,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#5a2"),
 		Error:       lipgloss.Color("#F00"),
-		ChromaStyle: styles.Abap,
+		ChromaStyle: styles.Get("abap"),
 	},
 	"algol": {
 		Primary:     lipgloss.Color("#5a2"),
@@ -79,7 +79,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#5a2"),
 		Error:       lipgloss.Color("#FF0000"),
-		ChromaStyle: styles.Algol,
+		ChromaStyle: styles.Get("algol"),
 	},
 	"arduino": {
 		Primary:     lipgloss.Color("#1e90ff"),
@@ -87,7 +87,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#5a2"),
 		Error:       lipgloss.Color("#F00"),
-		ChromaStyle: styles.Arduino,
+		ChromaStyle: styles.Get("arduino"),
 	},
 	"autumn": {
 		Primary:     lipgloss.Color("#aa5500"),
@@ -95,7 +95,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#009999"),
 		Error:       lipgloss.Color("#ff0000"),
-		ChromaStyle: styles.Autumn,
+		ChromaStyle: styles.Get("autumn"),
 	},
 	"average": {
 		Primary:     lipgloss.Color("#ec0000"),
@@ -103,7 +103,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#008900"),
 		Error:       lipgloss.Color("#ec0000"),
-		ChromaStyle: styles.Average,
+		ChromaStyle: styles.Get("average"),
 	},
 	"base16-snazzy": {
 		Primary:     lipgloss.Color("#ff6ac1"),
@@ -111,7 +111,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#5af78e"),
 		Error:       lipgloss.Color("#ff5c57"),
-		ChromaStyle: styles.Base16Snazzy,
+		ChromaStyle: styles.Get("base16-snazzy"),
 	},
 	"borland": {
 		Primary:     lipgloss.Color("#00f"),
@@ -119,7 +119,39 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#5a2"),
 		Error:       lipgloss.Color("#a61717"),
-		ChromaStyle: styles.Borland,
+		ChromaStyle: styles.Get("borland"),
+	},
+	"catppuccin-latte": {
+		Primary:     lipgloss.Color("#179299"),
+		Secondary:   lipgloss.Color("#1e66f5"),
+		Inactive:    GREY,
+		Success:     lipgloss.Color("#40a02b"),
+		Error:       lipgloss.Color("#d20f39"),
+		ChromaStyle: styles.Get("catppuccin-latte"),
+	},
+	"catppuccin-frappe": {
+		Primary:     lipgloss.Color("#81c8be"),
+		Secondary:   lipgloss.Color("#8caaee"),
+		Inactive:    GREY,
+		Success:     lipgloss.Color("#a6d189"),
+		Error:       lipgloss.Color("#e78284"),
+		ChromaStyle: styles.Get("catppuccin-frappe"),
+	},
+	"catppuccin-macchiato": {
+		Primary:     lipgloss.Color("#8bd5ca"),
+		Secondary:   lipgloss.Color("#8aadf4"),
+		Inactive:    GREY,
+		Success:     lipgloss.Color("#a6da95"),
+		Error:       lipgloss.Color("#ed8796"),
+		ChromaStyle: styles.Get("catppuccin-macchiato"),
+	},
+	"catppuccin-mocha": {
+		Primary:     lipgloss.Color("#94e2d5"),
+		Secondary:   lipgloss.Color("#89b4fa"),
+		Inactive:    GREY,
+		Success:     lipgloss.Color("#a6e3a1"),
+		Error:       lipgloss.Color("#f38ba8"),
+		ChromaStyle: styles.Get("catppuccin-mocha"),
 	},
 	"colorful": {
 		Primary:     lipgloss.Color("#00d"),
@@ -127,7 +159,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#070"),
 		Error:       lipgloss.Color("#a61717"),
-		ChromaStyle: styles.Colorful,
+		ChromaStyle: styles.Get("colorful"),
 	},
 	"doom-one": {
 		Primary:     lipgloss.Color("#b756ff"),
@@ -135,7 +167,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#63c381"),
 		Error:       lipgloss.Color("#e06c75"),
-		ChromaStyle: styles.DoomOne,
+		ChromaStyle: styles.Get("doom-one"),
 	},
 	"doom-one2": {
 		Primary:     lipgloss.Color("#76a9f9"),
@@ -143,7 +175,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#63c381"),
 		Error:       lipgloss.Color("#e06c75"),
-		ChromaStyle: styles.DoomOne2,
+		ChromaStyle: styles.Get("doom-one2"),
 	},
 	"dracula": {
 		Primary:     lipgloss.Color("#8be9fd"),
@@ -151,7 +183,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#50fa7b"),
 		Error:       lipgloss.Color("#f8f8f2"),
-		ChromaStyle: styles.Dracula,
+		ChromaStyle: styles.Get("dracula"),
 	},
 	"emacs": {
 		Primary:     lipgloss.Color("#008000"),
@@ -159,7 +191,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#008000"),
 		Error:       lipgloss.Color("#b44"),
-		ChromaStyle: styles.Emacs,
+		ChromaStyle: styles.Get("emacs"),
 	},
 	"friendly": {
 		Primary:     lipgloss.Color("#40a070"),
@@ -167,7 +199,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#40a070"),
 		Error:       lipgloss.Color("#FF0000"),
-		ChromaStyle: styles.Friendly,
+		ChromaStyle: styles.Get("friendly"),
 	},
 	"fruity": {
 		Primary:     lipgloss.Color("#fb660a"),
@@ -175,7 +207,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#40a070"),
 		Error:       lipgloss.Color("#FF0000"),
-		ChromaStyle: styles.Fruity,
+		ChromaStyle: styles.Get("fruity"),
 	},
 	"github": {
 		Primary:     lipgloss.Color("#d14"),
@@ -183,7 +215,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#099"),
 		Error:       lipgloss.Color("#d14"),
-		ChromaStyle: styles.GitHub,
+		ChromaStyle: styles.Get("github"),
 	},
 	"github-dark": {
 		Primary:     lipgloss.Color("#d2a8ff"),
@@ -191,7 +223,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#56d364"),
 		Error:       lipgloss.Color("#ffa198"),
-		ChromaStyle: styles.GitHubDark,
+		ChromaStyle: styles.Get("github-dark"),
 	},
 	"gruvbox": {
 		Primary:     lipgloss.Color("#b8bb26"),
@@ -199,7 +231,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#b8bb26"),
 		Error:       lipgloss.Color("#fb4934"),
-		ChromaStyle: styles.Gruvbox,
+		ChromaStyle: styles.Get("gruvbox"),
 	},
 	"gruvbox-light": {
 		Primary:     lipgloss.Color("#fb4934"),
@@ -207,7 +239,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#b8bb26"),
 		Error:       lipgloss.Color("#9D0006"),
-		ChromaStyle: styles.GruvboxLight,
+		ChromaStyle: styles.Get("gruvbox-light"),
 	},
 	"hrdark": {
 		Primary:     lipgloss.Color("#58a1dd"),
@@ -215,7 +247,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#a6be9d"),
 		Error:       lipgloss.Color("#FF0000"),
-		ChromaStyle: styles.HrDark,
+		ChromaStyle: styles.Get("hrdark"),
 	},
 	"igor": {
 		Primary:     lipgloss.Color("#009c00"),
@@ -223,7 +255,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#009c00"),
 		Error:       lipgloss.Color("#FF0000"),
-		ChromaStyle: styles.Igor,
+		ChromaStyle: styles.Get("igor"),
 	},
 	"lovelace": {
 		Primary:     lipgloss.Color("#b83838"),
@@ -231,7 +263,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#009c00"),
 		Error:       lipgloss.Color("#b83838"),
-		ChromaStyle: styles.Igor,
+		ChromaStyle: styles.Get("lovelace"),
 	},
 	"manni": {
 		Primary:     lipgloss.Color("#c30"),
@@ -239,7 +271,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#009c00"),
 		Error:       lipgloss.Color("#c30"),
-		ChromaStyle: styles.Manni,
+		ChromaStyle: styles.Get("manni"),
 	},
 	"monokai": {
 		Primary:     lipgloss.Color("#a6e22e"),
@@ -247,7 +279,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#b4d273"),
 		Error:       lipgloss.Color("#960050"),
-		ChromaStyle: styles.Monokai,
+		ChromaStyle: styles.Get("monokai"),
 	},
 	"monokai-light": {
 		Primary:     lipgloss.Color("#00a8c8"),
@@ -255,7 +287,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#b4d273"),
 		Error:       lipgloss.Color("#960050"),
-		ChromaStyle: styles.MonokaiLight,
+		ChromaStyle: styles.Get("monokai-light"),
 	},
 	"murphy": {
 		Primary:     lipgloss.Color("#070"),
@@ -263,7 +295,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#070"),
 		Error:       lipgloss.Color("#F00"),
-		ChromaStyle: styles.Murphy,
+		ChromaStyle: styles.Get("murphy"),
 	},
 	"native": {
 		Primary:     lipgloss.Color("#6ab825"),
@@ -271,7 +303,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#6ab825"),
 		Error:       lipgloss.Color("#a61717"),
-		ChromaStyle: styles.Native,
+		ChromaStyle: styles.Get("native"),
 	},
 	"nord": {
 		Primary:     nord7,
@@ -279,7 +311,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     nord14,
 		Error:       nord11,
-		ChromaStyle: styles.Nord,
+		ChromaStyle: styles.Get("nord"),
 	},
 	"onesenterprise": {
 		Primary:     lipgloss.Color("#00f"),
@@ -287,7 +319,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#6ab825"),
 		Error:       lipgloss.Color("#f00"),
-		ChromaStyle: styles.OnesEnterprise,
+		ChromaStyle: styles.Get("onesenterprise"),
 	},
 	"pastie": {
 		Primary:     lipgloss.Color("#b06"),
@@ -295,7 +327,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#080"),
 		Error:       lipgloss.Color("#d20"),
-		ChromaStyle: styles.Pastie,
+		ChromaStyle: styles.Get("pastie"),
 	},
 	"perldoc": {
 		Primary:     lipgloss.Color("#8b008b"),
@@ -303,7 +335,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#080"),
 		Error:       lipgloss.Color("#cd5555"),
-		ChromaStyle: styles.Perldoc,
+		ChromaStyle: styles.Get("perldoc"),
 	},
 	"paradaiso-dark": {
 		Primary:     lipgloss.Color("#48b685"),
@@ -311,7 +343,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#48b685"),
 		Error:       lipgloss.Color("#ef6155"),
-		ChromaStyle: styles.ParaisoDark,
+		ChromaStyle: styles.Get("paradaiso-dark"),
 	},
 	"paradaiso-light": {
 		Primary:     lipgloss.Color("#48b685"),
@@ -319,7 +351,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#48b685"),
 		Error:       lipgloss.Color("#ef6155"),
-		ChromaStyle: styles.ParaisoLight,
+		ChromaStyle: styles.Get("paradaiso-light"),
 	},
 	"pygments": {
 		Primary:     lipgloss.Color("#008000"),
@@ -327,7 +359,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#008000"),
 		Error:       lipgloss.Color("#ba2121"),
-		ChromaStyle: styles.Pygments,
+		ChromaStyle: styles.Get("pygments"),
 	},
 	"rainbow_dash": {
 		Primary:     lipgloss.Color("#0c6"),
@@ -335,7 +367,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#0c6"),
 		Error:       lipgloss.Color("#ba2121"),
-		ChromaStyle: styles.RainbowDash,
+		ChromaStyle: styles.Get("rainbow_dash"),
 	},
 	"rrt": {
 		Primary:     lipgloss.Color("#f60"),
@@ -343,7 +375,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#0c6"),
 		Error:       lipgloss.Color("#f00"),
-		ChromaStyle: styles.Rrt,
+		ChromaStyle: styles.Get("rrt"),
 	},
 	"solarized-dark": {
 		Primary:     lipgloss.Color("#268bd2"),
@@ -351,7 +383,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#0c6"),
 		Error:       lipgloss.Color("#cb4b16"),
-		ChromaStyle: styles.SolarizedDark,
+		ChromaStyle: styles.Get("solarized-dark"),
 	},
 	"solarized-dark256": {
 		Primary:     lipgloss.Color("#0087ff"),
@@ -359,7 +391,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#0c6"),
 		Error:       lipgloss.Color("#d75f00"),
-		ChromaStyle: styles.SolarizedDark256,
+		ChromaStyle: styles.Get("solarized-dark256"),
 	},
 	"solarized-light": {
 		Primary:     lipgloss.Color("#268bd2"),
@@ -367,7 +399,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#859900"),
 		Error:       lipgloss.Color("#d75f00"),
-		ChromaStyle: styles.SolarizedLight,
+		ChromaStyle: styles.Get("solarized-light"),
 	},
 	"swapoff": {
 		Primary:     lipgloss.Color("#0ff"),
@@ -375,7 +407,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#e5e5e5"),
 		Error:       lipgloss.Color("#e5e5e5"),
-		ChromaStyle: styles.SwapOff,
+		ChromaStyle: styles.Get("swapoff"),
 	},
 	"tango": {
 		Primary:     lipgloss.Color("#204a87"),
@@ -383,7 +415,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#4e9a06"),
 		Error:       lipgloss.Color("#a40000"),
-		ChromaStyle: styles.Tango,
+		ChromaStyle: styles.Get("tango"),
 	},
 	"trac": {
 		Primary:     lipgloss.Color("#099"),
@@ -391,7 +423,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#099"),
 		Error:       lipgloss.Color("#a61717"),
-		ChromaStyle: styles.Trac,
+		ChromaStyle: styles.Get("trac"),
 	},
 	"vim": {
 		Primary:     lipgloss.Color("#cd00cd"),
@@ -399,7 +431,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#66FF00"),
 		Error:       lipgloss.Color("#cd0000"),
-		ChromaStyle: styles.Vim,
+		ChromaStyle: styles.Get("vim"),
 	},
 	"visual_studio": {
 		Primary:     lipgloss.Color("#a31515"),
@@ -407,7 +439,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#023020"),
 		Error:       lipgloss.Color("#a31515"),
-		ChromaStyle: styles.VisualStudio,
+		ChromaStyle: styles.Get("vs"),
 	},
 	"vulcan": {
 		Primary:     lipgloss.Color("#bc74c4"),
@@ -415,7 +447,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#82cc6a"),
 		Error:       lipgloss.Color("#cf5967"),
-		ChromaStyle: styles.Vulcan,
+		ChromaStyle: styles.Get("vulcan"),
 	},
 	"witchhazel": {
 		Primary:     lipgloss.Color("#ffb8d1"),
@@ -423,7 +455,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#c2ffdf"),
 		Error:       lipgloss.Color("#ffb8d1"),
-		ChromaStyle: styles.WitchHazel,
+		ChromaStyle: styles.Get("witchhazel"),
 	},
 	"xcode": {
 		Primary:     lipgloss.Color("#c41a16"),
@@ -431,7 +463,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#023020"),
 		Error:       lipgloss.Color("#c41a16"),
-		ChromaStyle: styles.Xcode,
+		ChromaStyle: styles.Get("xcode"),
 	},
 	"xcode-dark": {
 		Primary:     lipgloss.Color("#fc6a5d"),
@@ -439,7 +471,7 @@ var themeMap = map[string]Theme{
 		Inactive:    GREY,
 		Success:     lipgloss.Color("#90EE90"),
 		Error:       lipgloss.Color("#fc6a5d"),
-		ChromaStyle: styles.XcodeDark,
+		ChromaStyle: styles.Get("xcode-dark"),
 	},
 }
 


### PR DESCRIPTION
Really love this tool but I was missing catppuccin colors.

I had to update chroma to the latest version to get the syntax colors as well and updated the way chroma styles are referenced as the old way got deprecated.

I also found a small copy/paste error with the lovelace theme which was using igor syntax colors while going through all the themes.

I tested all themes and they seemed to still be working, but maybe double check that I didn't miss anything.