### PR TITLE
fix: only log to stderr if there's an error reading the config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,24 +104,31 @@ func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory
-		viper.AddConfigPath(home)
-
-		// register the config file
-		viper.SetConfigName(".jqp")
-
-		//only read from yaml files
-		viper.SetConfigType("yaml")
-
+		if err := viper.ReadInConfig(); err != nil {
+			fmt.Fprintf(os.Stderr, "Config file %s was unable to be read: %v\n", viper.ConfigFileUsed(), err)
+		}
+		return
 	}
+	// Find home directory.
+	home, err := os.UserHomeDir()
+	cobra.CheckErr(err)
 
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Config file:", viper.ConfigFileUsed(), "was used.")
+	// Search config in home directory
+	viper.AddConfigPath(home)
+
+	// register the config file
+	viper.SetConfigName(".jqp")
+
+	//only read from yaml files
+	viper.SetConfigType("yaml")
+
+	// Try to read the default config file
+	if err := viper.ReadInConfig(); err != nil {
+		// Check if the error is due to the file not existing
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			// For errors other than file not found, print the error message
+			fmt.Fprintf(os.Stderr, "Default config file %s was unable to be read: %v\n", viper.ConfigFileUsed(), err)
+		}
 	}
 }
 


### PR DESCRIPTION
- `jqp` used to print to stdout which config file was used. This is pretty unnecessary so instead this will make `jqp` print to stderr under the following conditions:
  1. A config file specified via the `--config` parameter is unable to be read (due to potentially file not found, permissions, etc)
  2. If the config file is being read in from the default location (`$HOME/.jqp.yaml`), any error occurred _except_ the file not being found
     - The reason we ignore the file not being found in this case is that many users will not have a config file and thus it doesn't make sense to alarm them about this. 