### PR TITLE
feat: add optional cli argument to specify initial query

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/bubbletea"
@@ -15,12 +16,23 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Version:      "0.6.0",
-	Use:          "jqp",
-	Short:        "jqp is a TUI to explore jq",
-	Long:         `jqp is a TUI to explore the jq command line utility`,
+	Version: "0.6.0",
+	Use:     "jqp [query]",
+	Short:   "jqp is a TUI to explore jq",
+	Long: `jqp is a terminal user interface (TUI) for exploring the jq command line utility.
+	
+You can use it to run jq queries interactively. If no query is provided, the interface will prompt you for one.
+
+The command accepts an optional query argument which will be executed against the input JSON. 
+You can provide the input JSON either through a file or via standard input (stdin).`,
+	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		query := ""
+		if len(args) == 1 {
+			query = strings.TrimSpace(args[0])
+		}
+
 		configTheme := viper.GetString(configKeysName.themeName)
 		if !cmd.Flags().Changed(flagsName.theme) {
 			flags.theme = configTheme
@@ -62,7 +74,7 @@ var rootCmd = &cobra.Command{
 				return err
 			}
 
-			bubble, err := jqplayground.New(stdin, "STDIN", jqtheme, isJSONLines)
+			bubble, err := jqplayground.New(stdin, "STDIN", query, jqtheme, isJSONLines)
 			if err != nil {
 				return err
 			}
@@ -98,7 +110,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		bubble, err := jqplayground.New(data, fi.Name(), jqtheme, isJSONLines)
+		bubble, err := jqplayground.New(data, fi.Name(), query, jqtheme, isJSONLines)
 		if err != nil {
 			return err
 		}

--- a/tui/bubbles/jqplayground/commands.go
+++ b/tui/bubbles/jqplayground/commands.go
@@ -74,7 +74,6 @@ func processJSONLinesWithQuery(ctx context.Context, results *strings.Builder, qu
 		}
 	}
 	return nil
-
 }
 
 func (b *Bubble) executeQueryOnInput(ctx context.Context) (string, error) {
@@ -93,7 +92,6 @@ func (b *Bubble) executeQueryOnInput(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return results.String(), nil
-
 }
 
 func (b *Bubble) executeQueryCommand(ctx context.Context) tea.Cmd {

--- a/tui/bubbles/jqplayground/init.go
+++ b/tui/bubbles/jqplayground/init.go
@@ -5,5 +5,10 @@ import (
 )
 
 func (b Bubble) Init() tea.Cmd {
-	return b.queryinput.Init()
+	var cmds []tea.Cmd
+	if b.queryinput.GetInputValue() != "" {
+		b.executeQuery(&cmds)
+	}
+	cmds = append(cmds, b.queryinput.Init())
+	return tea.Batch(cmds...)
 }

--- a/tui/bubbles/jqplayground/model.go
+++ b/tui/bubbles/jqplayground/model.go
@@ -35,7 +35,7 @@ type Bubble struct {
 	isJSONLines      bool
 }
 
-func New(inputJSON []byte, filename string, jqtheme theme.Theme, isJSONLines bool) (Bubble, error) {
+func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, isJSONLines bool) (Bubble, error) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		return Bubble{}, err
@@ -51,11 +51,15 @@ func New(inputJSON []byte, filename string, jqtheme theme.Theme, isJSONLines boo
 	if err != nil {
 		return Bubble{}, err
 	}
+	queryInput := queryinput.New(jqtheme)
+	if query != "" {
+		queryInput.SetQuery(query)
+	}
 
 	b := Bubble{
 		workingDirectory: workingDirectory,
 		state:            state.Query,
-		queryinput:       queryinput.New(jqtheme),
+		queryinput:       queryInput,
 		inputdata:        inputData,
 		output:           output.New(jqtheme),
 		help:             help.New(jqtheme),

--- a/tui/bubbles/queryinput/queryinput.go
+++ b/tui/bubbles/queryinput/queryinput.go
@@ -77,6 +77,10 @@ func (b Bubble) Update(msg tea.Msg) (Bubble, tea.Cmd) {
 	}
 }
 
+func (b *Bubble) SetQuery(query string) {
+	b.textinput.SetValue(query)
+}
+
 func (b Bubble) updateKeyMsg(msg tea.KeyMsg) (Bubble, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyUp:


### PR DESCRIPTION
- address #65 
- adds an optional argument to the CLI to provide an initial query for `jqp` to execute on startup.
- example usage:

```
 curl "https://dummyjson.com/posts" | go run main.go ".posts[0]"
```

![optional-query-arg](https://github.com/noahgorstein/jqp/assets/23270779/7ac98c96-af62-4eab-8f95-b1822ce65e5f)
