### PR TITLE
feat: implement json schema for config

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-identifiers-re = ["nd"]

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,507 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "jqp settings",
+    "description": "jqp settings",
+    "type": "object",
+    "properties": {
+        "theme": {
+            "title": "theme",
+            "description": "A theme",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "name",
+                    "description": "A theme name",
+                    "type": "string",
+                    "minLength": 1,
+                    "enum": [
+                        "abap",
+                        "algol",
+                        "arduino",
+                        "autumn",
+                        "borland",
+                        "catppuccin-latte",
+                        "colorful",
+                        "emacs",
+                        "friendly",
+                        "github",
+                        "gruvbox-light",
+                        "hrdark",
+                        "igor",
+                        "lovelace",
+                        "manni",
+                        "monokai-light",
+                        "murphy",
+                        "onesenterprise",
+                        "paradaiso-light",
+                        "pastie",
+                        "perldoc",
+                        "pygments",
+                        "solarized-light",
+                        "tango",
+                        "trac",
+                        "visual_studio",
+                        "vulcan",
+                        "xcode",
+                        "average",
+                        "base16snazzy",
+                        "catppuccin-frappe",
+                        "catppuccin-macchiato",
+                        "catppuccin-mocha",
+                        "doom-one",
+                        "doom-one2",
+                        "dracula",
+                        "fruity",
+                        "github-dark",
+                        "gruvbox",
+                        "monokai",
+                        "native",
+                        "paradaiso-dark",
+                        "rrt",
+                        "solarized-dark",
+                        "solarized-dark256",
+                        "swapoff",
+                        "vim",
+                        "witchhazel",
+                        "xcode-dark"
+                    ]
+                },
+                "chromaStyleOverrides": {
+                    "title": "chroma style overrides",
+                    "description": "Chroma style overrides",
+                    "type": "object",
+                    "properties": {
+                        "bg": {
+                            "title": "bg",
+                            "description": "A property which corresponds to Background",
+                            "type": "string"
+                        },
+                        "chroma": {
+                            "title": "chroma",
+                            "description": "A property which corresponds to PreWrapper",
+                            "type": "string"
+                        },
+                        "line": {
+                            "title": "line",
+                            "description": "A property which corresponds to Line",
+                            "type": "string"
+                        },
+                        "ln": {
+                            "title": "ln",
+                            "description": "A property which corresponds to LineNumbers",
+                            "type": "string"
+                        },
+                        "lnt": {
+                            "title": "lnt",
+                            "description": "A property which corresponds to LineNumbersTable",
+                            "type": "string"
+                        },
+                        "hl": {
+                            "title": "hl",
+                            "description": "A property which corresponds to LineHighlight",
+                            "type": "string"
+                        },
+                        "lntable": {
+                            "title": "lntable",
+                            "description": "A property which corresponds to LineTable",
+                            "type": "string"
+                        },
+                        "lntd": {
+                            "title": "lntd",
+                            "description": "A property which corresponds to LineTableTD",
+                            "type": "string"
+                        },
+                        "cl": {
+                            "title": "cl",
+                            "description": "A property which corresponds to CodeLine",
+                            "type": "string"
+                        },
+                        "w": {
+                            "title": "w",
+                            "description": "A property which corresponds to Whitespace",
+                            "type": "string"
+                        },
+                        "err": {
+                            "title": "err",
+                            "description": "A property which corresponds to Error",
+                            "type": "string"
+                        },
+                        "x": {
+                            "title": "x",
+                            "description": "A property which corresponds to Other",
+                            "type": "string"
+                        },
+                        "k": {
+                            "title": "k",
+                            "description": "A property which corresponds to Keyword",
+                            "type": "string"
+                        },
+                        "kc": {
+                            "title": "kc",
+                            "description": "A property which corresponds to KeywordConstant",
+                            "type": "string"
+                        },
+                        "kd": {
+                            "title": "kd",
+                            "description": "A property which corresponds to KeywordDeclaration",
+                            "type": "string"
+                        },
+                        "kn": {
+                            "title": "kn",
+                            "description": "A property which corresponds to KeywordNamespace",
+                            "type": "string"
+                        },
+                        "kp": {
+                            "title": "kp",
+                            "description": "A property which corresponds to KeywordPseudo",
+                            "type": "string"
+                        },
+                        "kr": {
+                            "title": "kr",
+                            "description": "A property which corresponds to KeywordReserved",
+                            "type": "string"
+                        },
+                        "kt": {
+                            "title": "kt",
+                            "description": "A property which corresponds to KeywordType",
+                            "type": "string"
+                        },
+                        "n": {
+                            "title": "n",
+                            "description": "A property which corresponds to Name",
+                            "type": "string"
+                        },
+                        "na": {
+                            "title": "na",
+                            "description": "A property which corresponds to NameAttribute",
+                            "type": "string"
+                        },
+                        "nb": {
+                            "title": "nb",
+                            "description": "A property which corresponds to NameBuiltin",
+                            "type": "string"
+                        },
+                        "bp": {
+                            "title": "bp",
+                            "description": "A property which corresponds to NameBuiltinPseudo",
+                            "type": "string"
+                        },
+                        "nc": {
+                            "title": "nc",
+                            "description": "A property which corresponds to NameClass",
+                            "type": "string"
+                        },
+                        "no": {
+                            "title": "no",
+                            "description": "A property which corresponds to NameConstant",
+                            "type": "string"
+                        },
+                        "nd": {
+                            "title": "nd",
+                            "description": "A property which corresponds to NameDecorator",
+                            "type": "string"
+                        },
+                        "ni": {
+                            "title": "ni",
+                            "description": "A property which corresponds to NameEntity",
+                            "type": "string"
+                        },
+                        "ne": {
+                            "title": "ne",
+                            "description": "A property which corresponds to NameException",
+                            "type": "string"
+                        },
+                        "nf": {
+                            "title": "nf",
+                            "description": "A property which corresponds to NameFunction",
+                            "type": "string"
+                        },
+                        "fm": {
+                            "title": "fm",
+                            "description": "A property which corresponds to NameFunctionMagic",
+                            "type": "string"
+                        },
+                        "py": {
+                            "title": "py",
+                            "description": "A property which corresponds to NameProperty",
+                            "type": "string"
+                        },
+                        "nl": {
+                            "title": "nl",
+                            "description": "A property which corresponds to NameLabel",
+                            "type": "string"
+                        },
+                        "nn": {
+                            "title": "nn",
+                            "description": "A property which corresponds to NameNamespace",
+                            "type": "string"
+                        },
+                        "nx": {
+                            "title": "nx",
+                            "description": "A property which corresponds to NameOther",
+                            "type": "string"
+                        },
+                        "nt": {
+                            "title": "nt",
+                            "description": "A property which corresponds to NameTag",
+                            "type": "string"
+                        },
+                        "nv": {
+                            "title": "nv",
+                            "description": "A property which corresponds to NameVariable",
+                            "type": "string"
+                        },
+                        "vc": {
+                            "title": "vc",
+                            "description": "A property which corresponds to NameVariableClass",
+                            "type": "string"
+                        },
+                        "vg": {
+                            "title": "vg",
+                            "description": "A property which corresponds to NameVariableGlobal",
+                            "type": "string"
+                        },
+                        "vi": {
+                            "title": "vi",
+                            "description": "A property which corresponds to NameVariableInstance",
+                            "type": "string"
+                        },
+                        "vm": {
+                            "title": "vm",
+                            "description": "A property which corresponds to NameVariableMagic",
+                            "type": "string"
+                        },
+                        "l": {
+                            "title": "l",
+                            "description": "A property which corresponds to Literal",
+                            "type": "string"
+                        },
+                        "ld": {
+                            "title": "ld",
+                            "description": "A property which corresponds to LiteralDate",
+                            "type": "string"
+                        },
+                        "s": {
+                            "title": "s",
+                            "description": "A property which corresponds to String",
+                            "type": "string"
+                        },
+                        "sa": {
+                            "title": "sa",
+                            "description": "A property which corresponds to StringAffix",
+                            "type": "string"
+                        },
+                        "sb": {
+                            "title": "sb",
+                            "description": "A property which corresponds to StringBacktick",
+                            "type": "string"
+                        },
+                        "sc": {
+                            "title": "sc",
+                            "description": "A property which corresponds to StringChar",
+                            "type": "string"
+                        },
+                        "dl": {
+                            "title": "dl",
+                            "description": "A property which corresponds to StringDelimiter",
+                            "type": "string"
+                        },
+                        "sd": {
+                            "title": "sd",
+                            "description": "A property which corresponds to StringDoc",
+                            "type": "string"
+                        },
+                        "s2": {
+                            "title": "s2",
+                            "description": "A property which corresponds to StringDouble",
+                            "type": "string"
+                        },
+                        "se": {
+                            "title": "se",
+                            "description": "A property which corresponds to StringEscape",
+                            "type": "string"
+                        },
+                        "sh": {
+                            "title": "sh",
+                            "description": "A property which corresponds to StringHeredoc",
+                            "type": "string"
+                        },
+                        "si": {
+                            "title": "si",
+                            "description": "A property which corresponds to StringInterpol",
+                            "type": "string"
+                        },
+                        "sx": {
+                            "title": "sx",
+                            "description": "A property which corresponds to StringOther",
+                            "type": "string"
+                        },
+                        "sr": {
+                            "title": "sr",
+                            "description": "A property which corresponds to StringRegex",
+                            "type": "string"
+                        },
+                        "s1": {
+                            "title": "s1",
+                            "description": "A property which corresponds to StringSingle",
+                            "type": "string"
+                        },
+                        "ss": {
+                            "title": "ss",
+                            "description": "A property which corresponds to StringSymbol",
+                            "type": "string"
+                        },
+                        "m": {
+                            "title": "m",
+                            "description": "A property which corresponds to Number",
+                            "type": "string"
+                        },
+                        "mb": {
+                            "title": "mb",
+                            "description": "A property which corresponds to NumberBin",
+                            "type": "string"
+                        },
+                        "mf": {
+                            "title": "mf",
+                            "description": "A property which corresponds to NumberFloat",
+                            "type": "string"
+                        },
+                        "mh": {
+                            "title": "mh",
+                            "description": "A property which corresponds to NumberHex",
+                            "type": "string"
+                        },
+                        "mi": {
+                            "title": "mi",
+                            "description": "A property which corresponds to NumberInteger",
+                            "type": "string"
+                        },
+                        "il": {
+                            "title": "il",
+                            "description": "A property which corresponds to NumberIntegerLong",
+                            "type": "string"
+                        },
+                        "mo": {
+                            "title": "mo",
+                            "description": "A property which corresponds to NumberOct",
+                            "type": "string"
+                        },
+                        "o": {
+                            "title": "o",
+                            "description": "A property which corresponds to Operator",
+                            "type": "string"
+                        },
+                        "ow": {
+                            "title": "ow",
+                            "description": "A property which corresponds to OperatorWord",
+                            "type": "string"
+                        },
+                        "p": {
+                            "title": "p",
+                            "description": "A property which corresponds to Punctuation",
+                            "type": "string"
+                        },
+                        "c": {
+                            "title": "c",
+                            "description": "A property which corresponds to Comment",
+                            "type": "string"
+                        },
+                        "ch": {
+                            "title": "ch",
+                            "description": "A property which corresponds to CommentHashbang",
+                            "type": "string"
+                        },
+                        "cm": {
+                            "title": "cm",
+                            "description": "A property which corresponds to CommentMultiline",
+                            "type": "string"
+                        },
+                        "cp": {
+                            "title": "cp",
+                            "description": "A property which corresponds to CommentPreproc",
+                            "type": "string"
+                        },
+                        "cpf": {
+                            "title": "cpf",
+                            "description": "A property which corresponds to CommentPreprocFile",
+                            "type": "string"
+                        },
+                        "c1": {
+                            "title": "c1",
+                            "description": "A property which corresponds to CommentSingle",
+                            "type": "string"
+                        },
+                        "cs": {
+                            "title": "cs",
+                            "description": "A property which corresponds to CommentSpecial",
+                            "type": "string"
+                        },
+                        "g": {
+                            "title": "g",
+                            "description": "A property which corresponds to Generic",
+                            "type": "string"
+                        },
+                        "gd": {
+                            "title": "gd",
+                            "description": "A property which corresponds to GenericDeleted",
+                            "type": "string"
+                        },
+                        "ge": {
+                            "title": "ge",
+                            "description": "A property which corresponds to GenericEmph",
+                            "type": "string"
+                        },
+                        "gr": {
+                            "title": "gr",
+                            "description": "A property which corresponds to GenericError",
+                            "type": "string"
+                        },
+                        "gh": {
+                            "title": "gh",
+                            "description": "A property which corresponds to GenericHeading",
+                            "type": "string"
+                        },
+                        "gi": {
+                            "title": "gi",
+                            "description": "A property which corresponds to GenericInserted",
+                            "type": "string"
+                        },
+                        "go": {
+                            "title": "go",
+                            "description": "A property which corresponds to GenericOutput",
+                            "type": "string"
+                        },
+                        "gp": {
+                            "title": "gp",
+                            "description": "A property which corresponds to GenericPrompt",
+                            "type": "string"
+                        },
+                        "gs": {
+                            "title": "gs",
+                            "description": "A property which corresponds to GenericStrong",
+                            "type": "string"
+                        },
+                        "gu": {
+                            "title": "gu",
+                            "description": "A property which corresponds to GenericSubheading",
+                            "type": "string"
+                        },
+                        "gt": {
+                            "title": "gt",
+                            "description": "A property which corresponds to GenericTraceback",
+                            "type": "string"
+                        },
+                        "gl": {
+                            "title": "gl",
+                            "description": "A property which corresponds to GenericUnderline",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,47 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "override": {
+            "type": "string",
+            "examples": [
+                "#000000",
+                "#FF0000",
+                "#00FF00",
+                "#0000FF",
+                "#FFFF00",
+                "#FF00FF",
+                "#00FFFF",
+                "#FFFFFF",
+                "bold",
+                "underline",
+                "italic",
+                "bold #000000",
+                "bold #FF0000",
+                "bold #00FF00",
+                "bold #0000FF",
+                "bold #FFFF00",
+                "bold #FF00FF",
+                "bold #00FFFF",
+                "bold #FFFFFF",
+                "italic #000000",
+                "italic #FF0000",
+                "italic #00FF00",
+                "italic #0000FF",
+                "italic #FFFF00",
+                "italic #FF00FF",
+                "italic #00FFFF",
+                "italic #FFFFFF",
+                "underline #000000",
+                "underline #FF0000",
+                "underline #00FF00",
+                "underline #0000FF",
+                "underline #FFFF00",
+                "underline #FF00FF",
+                "underline #00FFFF",
+                "underline #FFFFFF"
+            ]
+        }
+    },
     "title": "jqp settings",
     "description": "jqp settings\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#configuration",
     "type": "object",
@@ -74,427 +116,427 @@
                         "bg": {
                             "title": "bg",
                             "description": "A property which corresponds to Background\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "chroma": {
                             "title": "chroma",
                             "description": "A property which corresponds to PreWrapper\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "line": {
                             "title": "line",
                             "description": "A property which corresponds to Line\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ln": {
                             "title": "ln",
                             "description": "A property which corresponds to LineNumbers\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "lnt": {
                             "title": "lnt",
                             "description": "A property which corresponds to LineNumbersTable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "hl": {
                             "title": "hl",
                             "description": "A property which corresponds to LineHighlight\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "lntable": {
                             "title": "lntable",
                             "description": "A property which corresponds to LineTable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "lntd": {
                             "title": "lntd",
                             "description": "A property which corresponds to LineTableTD\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "cl": {
                             "title": "cl",
                             "description": "A property which corresponds to CodeLine\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "w": {
                             "title": "w",
                             "description": "A property which corresponds to Whitespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "err": {
                             "title": "err",
                             "description": "A property which corresponds to Error\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "x": {
                             "title": "x",
                             "description": "A property which corresponds to Other\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "k": {
                             "title": "k",
                             "description": "A property which corresponds to Keyword\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kc": {
                             "title": "kc",
                             "description": "A property which corresponds to KeywordConstant\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kd": {
                             "title": "kd",
                             "description": "A property which corresponds to KeywordDeclaration\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kn": {
                             "title": "kn",
                             "description": "A property which corresponds to KeywordNamespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kp": {
                             "title": "kp",
                             "description": "A property which corresponds to KeywordPseudo\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kr": {
                             "title": "kr",
                             "description": "A property which corresponds to KeywordReserved\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "kt": {
                             "title": "kt",
                             "description": "A property which corresponds to KeywordType\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "n": {
                             "title": "n",
                             "description": "A property which corresponds to Name\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "na": {
                             "title": "na",
                             "description": "A property which corresponds to NameAttribute\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nb": {
                             "title": "nb",
                             "description": "A property which corresponds to NameBuiltin\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "bp": {
                             "title": "bp",
                             "description": "A property which corresponds to NameBuiltinPseudo\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nc": {
                             "title": "nc",
                             "description": "A property which corresponds to NameClass\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "no": {
                             "title": "no",
                             "description": "A property which corresponds to NameConstant\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nd": {
                             "title": "nd",
                             "description": "A property which corresponds to NameDecorator\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ni": {
                             "title": "ni",
                             "description": "A property which corresponds to NameEntity\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ne": {
                             "title": "ne",
                             "description": "A property which corresponds to NameException\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nf": {
                             "title": "nf",
                             "description": "A property which corresponds to NameFunction\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "fm": {
                             "title": "fm",
                             "description": "A property which corresponds to NameFunctionMagic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "py": {
                             "title": "py",
                             "description": "A property which corresponds to NameProperty\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nl": {
                             "title": "nl",
                             "description": "A property which corresponds to NameLabel\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nn": {
                             "title": "nn",
                             "description": "A property which corresponds to NameNamespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nx": {
                             "title": "nx",
                             "description": "A property which corresponds to NameOther\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nt": {
                             "title": "nt",
                             "description": "A property which corresponds to NameTag\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "nv": {
                             "title": "nv",
                             "description": "A property which corresponds to NameVariable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "vc": {
                             "title": "vc",
                             "description": "A property which corresponds to NameVariableClass\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "vg": {
                             "title": "vg",
                             "description": "A property which corresponds to NameVariableGlobal\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "vi": {
                             "title": "vi",
                             "description": "A property which corresponds to NameVariableInstance\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "vm": {
                             "title": "vm",
                             "description": "A property which corresponds to NameVariableMagic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "l": {
                             "title": "l",
                             "description": "A property which corresponds to Literal\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ld": {
                             "title": "ld",
                             "description": "A property which corresponds to LiteralDate\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "s": {
                             "title": "s",
                             "description": "A property which corresponds to String\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sa": {
                             "title": "sa",
                             "description": "A property which corresponds to StringAffix\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sb": {
                             "title": "sb",
                             "description": "A property which corresponds to StringBacktick\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sc": {
                             "title": "sc",
                             "description": "A property which corresponds to StringChar\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "dl": {
                             "title": "dl",
                             "description": "A property which corresponds to StringDelimiter\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sd": {
                             "title": "sd",
                             "description": "A property which corresponds to StringDoc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "s2": {
                             "title": "s2",
                             "description": "A property which corresponds to StringDouble\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "se": {
                             "title": "se",
                             "description": "A property which corresponds to StringEscape\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sh": {
                             "title": "sh",
                             "description": "A property which corresponds to StringHeredoc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "si": {
                             "title": "si",
                             "description": "A property which corresponds to StringInterpol\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sx": {
                             "title": "sx",
                             "description": "A property which corresponds to StringOther\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "sr": {
                             "title": "sr",
                             "description": "A property which corresponds to StringRegex\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "s1": {
                             "title": "s1",
                             "description": "A property which corresponds to StringSingle\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ss": {
                             "title": "ss",
                             "description": "A property which corresponds to StringSymbol\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "m": {
                             "title": "m",
                             "description": "A property which corresponds to Number\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "mb": {
                             "title": "mb",
                             "description": "A property which corresponds to NumberBin\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "mf": {
                             "title": "mf",
                             "description": "A property which corresponds to NumberFloat\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "mh": {
                             "title": "mh",
                             "description": "A property which corresponds to NumberHex\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "mi": {
                             "title": "mi",
                             "description": "A property which corresponds to NumberInteger\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "il": {
                             "title": "il",
                             "description": "A property which corresponds to NumberIntegerLong\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "mo": {
                             "title": "mo",
                             "description": "A property which corresponds to NumberOct\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "o": {
                             "title": "o",
                             "description": "A property which corresponds to Operator\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ow": {
                             "title": "ow",
                             "description": "A property which corresponds to OperatorWord\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "p": {
                             "title": "p",
                             "description": "A property which corresponds to Punctuation\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "c": {
                             "title": "c",
                             "description": "A property which corresponds to Comment\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ch": {
                             "title": "ch",
                             "description": "A property which corresponds to CommentHashbang\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "cm": {
                             "title": "cm",
                             "description": "A property which corresponds to CommentMultiline\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "cp": {
                             "title": "cp",
                             "description": "A property which corresponds to CommentPreproc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "cpf": {
                             "title": "cpf",
                             "description": "A property which corresponds to CommentPreprocFile\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "c1": {
                             "title": "c1",
                             "description": "A property which corresponds to CommentSingle\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "cs": {
                             "title": "cs",
                             "description": "A property which corresponds to CommentSpecial\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "g": {
                             "title": "g",
                             "description": "A property which corresponds to Generic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gd": {
                             "title": "gd",
                             "description": "A property which corresponds to GenericDeleted\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "ge": {
                             "title": "ge",
                             "description": "A property which corresponds to GenericEmph\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gr": {
                             "title": "gr",
                             "description": "A property which corresponds to GenericError\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gh": {
                             "title": "gh",
                             "description": "A property which corresponds to GenericHeading\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gi": {
                             "title": "gi",
                             "description": "A property which corresponds to GenericInserted\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "go": {
                             "title": "go",
                             "description": "A property which corresponds to GenericOutput\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gp": {
                             "title": "gp",
                             "description": "A property which corresponds to GenericPrompt\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gs": {
                             "title": "gs",
                             "description": "A property which corresponds to GenericStrong\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gu": {
                             "title": "gu",
                             "description": "A property which corresponds to GenericSubheading\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gt": {
                             "title": "gt",
                             "description": "A property which corresponds to GenericTraceback\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         },
                         "gl": {
                             "title": "gl",
                             "description": "A property which corresponds to GenericUnderline\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
-                            "type": "string"
+                            "$ref": "#/definitions/override"
                         }
                     },
                     "minProperties": 1,

--- a/schema.json
+++ b/schema.json
@@ -1,17 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "jqp settings",
-    "description": "jqp settings",
+    "description": "jqp settings\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#configuration",
     "type": "object",
     "properties": {
         "theme": {
             "title": "theme",
-            "description": "A theme",
+            "description": "A theme\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#themes",
             "type": "object",
             "properties": {
                 "name": {
                     "title": "name",
-                    "description": "A theme name",
+                    "description": "A theme name\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#themes",
                     "type": "string",
                     "minLength": 1,
                     "enum": [
@@ -68,440 +68,443 @@
                 },
                 "chromaStyleOverrides": {
                     "title": "chroma style overrides",
-                    "description": "Chroma style overrides",
+                    "description": "Chroma style overrides\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                     "type": "object",
                     "properties": {
                         "bg": {
                             "title": "bg",
-                            "description": "A property which corresponds to Background",
+                            "description": "A property which corresponds to Background\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "chroma": {
                             "title": "chroma",
-                            "description": "A property which corresponds to PreWrapper",
+                            "description": "A property which corresponds to PreWrapper\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "line": {
                             "title": "line",
-                            "description": "A property which corresponds to Line",
+                            "description": "A property which corresponds to Line\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ln": {
                             "title": "ln",
-                            "description": "A property which corresponds to LineNumbers",
+                            "description": "A property which corresponds to LineNumbers\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "lnt": {
                             "title": "lnt",
-                            "description": "A property which corresponds to LineNumbersTable",
+                            "description": "A property which corresponds to LineNumbersTable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "hl": {
                             "title": "hl",
-                            "description": "A property which corresponds to LineHighlight",
+                            "description": "A property which corresponds to LineHighlight\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "lntable": {
                             "title": "lntable",
-                            "description": "A property which corresponds to LineTable",
+                            "description": "A property which corresponds to LineTable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "lntd": {
                             "title": "lntd",
-                            "description": "A property which corresponds to LineTableTD",
+                            "description": "A property which corresponds to LineTableTD\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "cl": {
                             "title": "cl",
-                            "description": "A property which corresponds to CodeLine",
+                            "description": "A property which corresponds to CodeLine\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "w": {
                             "title": "w",
-                            "description": "A property which corresponds to Whitespace",
+                            "description": "A property which corresponds to Whitespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "err": {
                             "title": "err",
-                            "description": "A property which corresponds to Error",
+                            "description": "A property which corresponds to Error\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "x": {
                             "title": "x",
-                            "description": "A property which corresponds to Other",
+                            "description": "A property which corresponds to Other\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "k": {
                             "title": "k",
-                            "description": "A property which corresponds to Keyword",
+                            "description": "A property which corresponds to Keyword\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kc": {
                             "title": "kc",
-                            "description": "A property which corresponds to KeywordConstant",
+                            "description": "A property which corresponds to KeywordConstant\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kd": {
                             "title": "kd",
-                            "description": "A property which corresponds to KeywordDeclaration",
+                            "description": "A property which corresponds to KeywordDeclaration\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kn": {
                             "title": "kn",
-                            "description": "A property which corresponds to KeywordNamespace",
+                            "description": "A property which corresponds to KeywordNamespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kp": {
                             "title": "kp",
-                            "description": "A property which corresponds to KeywordPseudo",
+                            "description": "A property which corresponds to KeywordPseudo\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kr": {
                             "title": "kr",
-                            "description": "A property which corresponds to KeywordReserved",
+                            "description": "A property which corresponds to KeywordReserved\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "kt": {
                             "title": "kt",
-                            "description": "A property which corresponds to KeywordType",
+                            "description": "A property which corresponds to KeywordType\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "n": {
                             "title": "n",
-                            "description": "A property which corresponds to Name",
+                            "description": "A property which corresponds to Name\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "na": {
                             "title": "na",
-                            "description": "A property which corresponds to NameAttribute",
+                            "description": "A property which corresponds to NameAttribute\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nb": {
                             "title": "nb",
-                            "description": "A property which corresponds to NameBuiltin",
+                            "description": "A property which corresponds to NameBuiltin\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "bp": {
                             "title": "bp",
-                            "description": "A property which corresponds to NameBuiltinPseudo",
+                            "description": "A property which corresponds to NameBuiltinPseudo\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nc": {
                             "title": "nc",
-                            "description": "A property which corresponds to NameClass",
+                            "description": "A property which corresponds to NameClass\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "no": {
                             "title": "no",
-                            "description": "A property which corresponds to NameConstant",
+                            "description": "A property which corresponds to NameConstant\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nd": {
                             "title": "nd",
-                            "description": "A property which corresponds to NameDecorator",
+                            "description": "A property which corresponds to NameDecorator\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ni": {
                             "title": "ni",
-                            "description": "A property which corresponds to NameEntity",
+                            "description": "A property which corresponds to NameEntity\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ne": {
                             "title": "ne",
-                            "description": "A property which corresponds to NameException",
+                            "description": "A property which corresponds to NameException\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nf": {
                             "title": "nf",
-                            "description": "A property which corresponds to NameFunction",
+                            "description": "A property which corresponds to NameFunction\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "fm": {
                             "title": "fm",
-                            "description": "A property which corresponds to NameFunctionMagic",
+                            "description": "A property which corresponds to NameFunctionMagic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "py": {
                             "title": "py",
-                            "description": "A property which corresponds to NameProperty",
+                            "description": "A property which corresponds to NameProperty\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nl": {
                             "title": "nl",
-                            "description": "A property which corresponds to NameLabel",
+                            "description": "A property which corresponds to NameLabel\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nn": {
                             "title": "nn",
-                            "description": "A property which corresponds to NameNamespace",
+                            "description": "A property which corresponds to NameNamespace\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nx": {
                             "title": "nx",
-                            "description": "A property which corresponds to NameOther",
+                            "description": "A property which corresponds to NameOther\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nt": {
                             "title": "nt",
-                            "description": "A property which corresponds to NameTag",
+                            "description": "A property which corresponds to NameTag\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "nv": {
                             "title": "nv",
-                            "description": "A property which corresponds to NameVariable",
+                            "description": "A property which corresponds to NameVariable\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "vc": {
                             "title": "vc",
-                            "description": "A property which corresponds to NameVariableClass",
+                            "description": "A property which corresponds to NameVariableClass\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "vg": {
                             "title": "vg",
-                            "description": "A property which corresponds to NameVariableGlobal",
+                            "description": "A property which corresponds to NameVariableGlobal\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "vi": {
                             "title": "vi",
-                            "description": "A property which corresponds to NameVariableInstance",
+                            "description": "A property which corresponds to NameVariableInstance\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "vm": {
                             "title": "vm",
-                            "description": "A property which corresponds to NameVariableMagic",
+                            "description": "A property which corresponds to NameVariableMagic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "l": {
                             "title": "l",
-                            "description": "A property which corresponds to Literal",
+                            "description": "A property which corresponds to Literal\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ld": {
                             "title": "ld",
-                            "description": "A property which corresponds to LiteralDate",
+                            "description": "A property which corresponds to LiteralDate\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "s": {
                             "title": "s",
-                            "description": "A property which corresponds to String",
+                            "description": "A property which corresponds to String\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sa": {
                             "title": "sa",
-                            "description": "A property which corresponds to StringAffix",
+                            "description": "A property which corresponds to StringAffix\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sb": {
                             "title": "sb",
-                            "description": "A property which corresponds to StringBacktick",
+                            "description": "A property which corresponds to StringBacktick\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sc": {
                             "title": "sc",
-                            "description": "A property which corresponds to StringChar",
+                            "description": "A property which corresponds to StringChar\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "dl": {
                             "title": "dl",
-                            "description": "A property which corresponds to StringDelimiter",
+                            "description": "A property which corresponds to StringDelimiter\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sd": {
                             "title": "sd",
-                            "description": "A property which corresponds to StringDoc",
+                            "description": "A property which corresponds to StringDoc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "s2": {
                             "title": "s2",
-                            "description": "A property which corresponds to StringDouble",
+                            "description": "A property which corresponds to StringDouble\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "se": {
                             "title": "se",
-                            "description": "A property which corresponds to StringEscape",
+                            "description": "A property which corresponds to StringEscape\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sh": {
                             "title": "sh",
-                            "description": "A property which corresponds to StringHeredoc",
+                            "description": "A property which corresponds to StringHeredoc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "si": {
                             "title": "si",
-                            "description": "A property which corresponds to StringInterpol",
+                            "description": "A property which corresponds to StringInterpol\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sx": {
                             "title": "sx",
-                            "description": "A property which corresponds to StringOther",
+                            "description": "A property which corresponds to StringOther\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "sr": {
                             "title": "sr",
-                            "description": "A property which corresponds to StringRegex",
+                            "description": "A property which corresponds to StringRegex\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "s1": {
                             "title": "s1",
-                            "description": "A property which corresponds to StringSingle",
+                            "description": "A property which corresponds to StringSingle\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ss": {
                             "title": "ss",
-                            "description": "A property which corresponds to StringSymbol",
+                            "description": "A property which corresponds to StringSymbol\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "m": {
                             "title": "m",
-                            "description": "A property which corresponds to Number",
+                            "description": "A property which corresponds to Number\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "mb": {
                             "title": "mb",
-                            "description": "A property which corresponds to NumberBin",
+                            "description": "A property which corresponds to NumberBin\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "mf": {
                             "title": "mf",
-                            "description": "A property which corresponds to NumberFloat",
+                            "description": "A property which corresponds to NumberFloat\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "mh": {
                             "title": "mh",
-                            "description": "A property which corresponds to NumberHex",
+                            "description": "A property which corresponds to NumberHex\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "mi": {
                             "title": "mi",
-                            "description": "A property which corresponds to NumberInteger",
+                            "description": "A property which corresponds to NumberInteger\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "il": {
                             "title": "il",
-                            "description": "A property which corresponds to NumberIntegerLong",
+                            "description": "A property which corresponds to NumberIntegerLong\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "mo": {
                             "title": "mo",
-                            "description": "A property which corresponds to NumberOct",
+                            "description": "A property which corresponds to NumberOct\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "o": {
                             "title": "o",
-                            "description": "A property which corresponds to Operator",
+                            "description": "A property which corresponds to Operator\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ow": {
                             "title": "ow",
-                            "description": "A property which corresponds to OperatorWord",
+                            "description": "A property which corresponds to OperatorWord\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "p": {
                             "title": "p",
-                            "description": "A property which corresponds to Punctuation",
+                            "description": "A property which corresponds to Punctuation\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "c": {
                             "title": "c",
-                            "description": "A property which corresponds to Comment",
+                            "description": "A property which corresponds to Comment\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ch": {
                             "title": "ch",
-                            "description": "A property which corresponds to CommentHashbang",
+                            "description": "A property which corresponds to CommentHashbang\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "cm": {
                             "title": "cm",
-                            "description": "A property which corresponds to CommentMultiline",
+                            "description": "A property which corresponds to CommentMultiline\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "cp": {
                             "title": "cp",
-                            "description": "A property which corresponds to CommentPreproc",
+                            "description": "A property which corresponds to CommentPreproc\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "cpf": {
                             "title": "cpf",
-                            "description": "A property which corresponds to CommentPreprocFile",
+                            "description": "A property which corresponds to CommentPreprocFile\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "c1": {
                             "title": "c1",
-                            "description": "A property which corresponds to CommentSingle",
+                            "description": "A property which corresponds to CommentSingle\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "cs": {
                             "title": "cs",
-                            "description": "A property which corresponds to CommentSpecial",
+                            "description": "A property which corresponds to CommentSpecial\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "g": {
                             "title": "g",
-                            "description": "A property which corresponds to Generic",
+                            "description": "A property which corresponds to Generic\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gd": {
                             "title": "gd",
-                            "description": "A property which corresponds to GenericDeleted",
+                            "description": "A property which corresponds to GenericDeleted\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "ge": {
                             "title": "ge",
-                            "description": "A property which corresponds to GenericEmph",
+                            "description": "A property which corresponds to GenericEmph\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gr": {
                             "title": "gr",
-                            "description": "A property which corresponds to GenericError",
+                            "description": "A property which corresponds to GenericError\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gh": {
                             "title": "gh",
-                            "description": "A property which corresponds to GenericHeading",
+                            "description": "A property which corresponds to GenericHeading\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gi": {
                             "title": "gi",
-                            "description": "A property which corresponds to GenericInserted",
+                            "description": "A property which corresponds to GenericInserted\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "go": {
                             "title": "go",
-                            "description": "A property which corresponds to GenericOutput",
+                            "description": "A property which corresponds to GenericOutput\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gp": {
                             "title": "gp",
-                            "description": "A property which corresponds to GenericPrompt",
+                            "description": "A property which corresponds to GenericPrompt\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gs": {
                             "title": "gs",
-                            "description": "A property which corresponds to GenericStrong",
+                            "description": "A property which corresponds to GenericStrong\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gu": {
                             "title": "gu",
-                            "description": "A property which corresponds to GenericSubheading",
+                            "description": "A property which corresponds to GenericSubheading\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gt": {
                             "title": "gt",
-                            "description": "A property which corresponds to GenericTraceback",
+                            "description": "A property which corresponds to GenericTraceback\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         },
                         "gl": {
                             "title": "gl",
-                            "description": "A property which corresponds to GenericUnderline",
+                            "description": "A property which corresponds to GenericUnderline\nhttps://github.com/noahgorstein/jqp?tab=readme-ov-file#chroma-style-overrides",
                             "type": "string"
                         }
                     },
+                    "minProperties": 1,
                     "additionalProperties": false
                 }
             },
+            "minProperties": 1,
             "additionalProperties": false
         }
     },
+    "minProperties": 1,
     "additionalProperties": false
 }


### PR DESCRIPTION
![image](https://github.com/noahgorstein/jqp/assets/42812113/b2ffeb9e-e591-4301-821c-e11fa0d11075)

Validates a config file.


> If this PR is accepted this schema is referenced in [SchemaStore](https://github.com/SchemaStore/schemastore) to automatically enable validation for `.jqp.yaml`.