### PR TITLE
fix: don't block while inputdata bubble initializes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 jqp
 dist/
+debug.log

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,20 +68,17 @@ You can provide the input JSON either through a file or via standard input (stdi
 			if err != nil {
 				return err
 			}
-
-			_, isJSONLines, err := isValidInput(stdin)
-			if err != nil {
-				return err
-			}
-
-			bubble, err := jqplayground.New(stdin, "STDIN", query, jqtheme, isJSONLines)
+			bubble, err := jqplayground.New(stdin, "STDIN", query, jqtheme)
 			if err != nil {
 				return err
 			}
 			p := tea.NewProgram(bubble, tea.WithAltScreen())
-			_, err = p.Run()
+			m, err := p.Run()
 			if err != nil {
 				return err
+			}
+			if m, ok := m.(jqplayground.Bubble); ok && m.ExitMessage != "" {
+				return errors.New(m.ExitMessage)
 			}
 			return nil
 		}
@@ -99,26 +96,24 @@ You can provide the input JSON either through a file or via standard input (stdi
 			return err
 		}
 
-		_, isJSONLines, err := isValidInput(data)
-		if err != nil {
-			return err
-		}
-
 		// get file info so we can get the filename
 		fi, err := os.Stat(flags.filepath)
 		if err != nil {
 			return err
 		}
 
-		bubble, err := jqplayground.New(data, fi.Name(), query, jqtheme, isJSONLines)
+		bubble, err := jqplayground.New(data, fi.Name(), query, jqtheme)
 		if err != nil {
 			return err
 		}
 		p := tea.NewProgram(bubble, tea.WithAltScreen())
 
-		_, err = p.Run()
+		m, err := p.Run()
 		if err != nil {
 			return err
+		}
+		if m, ok := m.(jqplayground.Bubble); ok && m.ExitMessage != "" {
+			return errors.New(m.ExitMessage)
 		}
 		return nil
 	},

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,22 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/noahgorstein/jqp/tui/utils"
 )
-
-// isValidInput checks the validity of input data as JSON or JSON lines.
-// It takes a byte slice 'data' and returns two boolean values indicating
-// whether the data is valid JSON and valid JSON lines, along with an error
-// if the data is not valid in either format.
-func isValidInput(data []byte) (isValidJSON bool, isValidJSONLines bool, err error) {
-	isValidJSON = utils.IsValidJSON(data)
-	isValidJSONLines = utils.IsValidJSONLines(data)
-	if !isValidJSON && !isValidJSONLines {
-		return false, false, errors.New("Data is not valid JSON or LDJSON")
-	}
-	return isValidJSON, isValidJSONLines, nil
-}
 
 func streamToBytes(stream io.Reader) ([]byte, error) {
 	buf := new(bytes.Buffer)

--- a/tui/bubbles/inputdata/inputdata.go
+++ b/tui/bubbles/inputdata/inputdata.go
@@ -14,41 +14,40 @@ import (
 )
 
 type Bubble struct {
-	Styles          Styles
-	viewport        viewport.Model
-	height          int
-	width           int
-	inputJSON       []byte
-	highlightedJSON *bytes.Buffer
-	filename        string
-	isJSONLines     bool
+	styles               Styles
+	viewport             viewport.Model
+	height               int
+	width                int
+	inputJSON            []byte
+	highlightedJSON      *bytes.Buffer
+	filename             string
+	loading              bool
+	theme                theme.Theme
+	setInitialContentSub chan setPrettifiedContentMsg
 }
 
-func New(inputJSON []byte, filename string, jqtheme theme.Theme, isJSONLines bool) (Bubble, error) {
+func New(inputJSON []byte, filename string, jqtheme theme.Theme) (Bubble, error) {
 	styles := DefaultStyles()
 	styles.containerStyle = styles.containerStyle.BorderForeground(jqtheme.Inactive)
 	styles.infoStyle = styles.infoStyle.BorderForeground(jqtheme.Inactive)
 
-	highlightedJSON, err := utils.Prettify(inputJSON, jqtheme.ChromaStyle, isJSONLines)
-	if err != nil {
-		return Bubble{}, err
-	}
-
 	v := viewport.New(0, 0)
+	v.SetContent("Loading...")
 	b := Bubble{
-		Styles:          styles,
-		viewport:        v,
-		inputJSON:       inputJSON,
-		highlightedJSON: highlightedJSON,
-		filename:        filename,
-		isJSONLines:     isJSONLines,
+		loading:              false,
+		styles:               styles,
+		viewport:             v,
+		inputJSON:            inputJSON,
+		filename:             filename,
+		theme:                jqtheme,
+		setInitialContentSub: make(chan setPrettifiedContentMsg),
 	}
 	return b, nil
 }
 
 func (b *Bubble) SetBorderColor(color lipgloss.TerminalColor) {
-	b.Styles.containerStyle.BorderForeground(color)
-	b.Styles.infoStyle.BorderForeground(color)
+	b.styles.containerStyle.BorderForeground(color)
+	b.styles.infoStyle.BorderForeground(color)
 }
 
 func (b Bubble) GetInputJSON() []byte {
@@ -63,12 +62,12 @@ func (b *Bubble) SetSize(width, height int) {
 	b.width = width
 	b.height = height
 
-	b.Styles.containerStyle.
-		Width(width - b.Styles.containerStyle.GetHorizontalFrameSize()/2).
-		Height(height - b.Styles.containerStyle.GetVerticalFrameSize())
+	b.styles.containerStyle.
+		Width(width - b.styles.containerStyle.GetHorizontalFrameSize()/2).
+		Height(height - b.styles.containerStyle.GetVerticalFrameSize())
 
-	b.viewport.Width = width - b.Styles.containerStyle.GetHorizontalFrameSize() - 3
-	b.viewport.Height = height - b.Styles.containerStyle.GetVerticalFrameSize() - 3
+	b.viewport.Width = width - b.styles.containerStyle.GetHorizontalFrameSize() - 3
+	b.viewport.Height = height - b.styles.containerStyle.GetVerticalFrameSize() - 3
 }
 
 func max(a, b int) int {
@@ -81,13 +80,13 @@ func max(a, b int) int {
 func (b Bubble) View() string {
 	scrollPercent := fmt.Sprintf("%3.f%%", b.viewport.ScrollPercent()*100)
 
-	info := b.Styles.infoStyle.Render(fmt.Sprintf("%s | %s", lipgloss.NewStyle().Italic(true).Render(b.filename), scrollPercent))
+	info := b.styles.infoStyle.Render(fmt.Sprintf("%s | %s", lipgloss.NewStyle().Italic(true).Render(b.filename), scrollPercent))
 	line := strings.Repeat(" ", max(0, b.viewport.Width-lipgloss.Width(info)))
 
 	footer := lipgloss.JoinHorizontal(lipgloss.Center, line, info)
 	content := lipgloss.JoinVertical(lipgloss.Left, b.viewport.View(), footer)
 
-	return b.Styles.containerStyle.Render(content)
+	return b.styles.containerStyle.Render(content)
 }
 
 func (b *Bubble) SetContent(content string) {
@@ -95,8 +94,37 @@ func (b *Bubble) SetContent(content string) {
 	b.viewport.SetContent(formattedContent)
 }
 
-func (Bubble) Init() tea.Cmd {
-	return nil
+// InputReadyMsg signals that the inputdata Bubble has loaded the user's data
+// into the viewport
+type InputReadyMsg struct{}
+
+type setPrettifiedContentMsg struct {
+	Content *bytes.Buffer
+}
+
+// setPrettifiedContentCmd sends the initial formatted JSON content to the provided channel once.
+//
+// Prettifying the JSON can be an expensive operation, so it is performed here and
+// sent through the channel to ensure the formatted data is available without blocking other operations.
+func (b Bubble) setInitialContentCmd(sub chan setPrettifiedContentMsg, isJSONLines bool) tea.Cmd {
+	return func() tea.Msg {
+		highlightedJSON, _ := utils.Prettify(b.inputJSON, b.theme.ChromaStyle, isJSONLines)
+		sub <- setPrettifiedContentMsg{Content: highlightedJSON}
+		return nil
+	}
+}
+
+// A command that waits for the prettified content on a channel.
+func waitForInitialContentReady(sub chan setPrettifiedContentMsg) tea.Cmd {
+	return func() tea.Msg {
+		return setPrettifiedContentMsg(<-sub)
+	}
+}
+
+func (b Bubble) Init(isJSONLines bool) tea.Cmd {
+	return tea.Batch(
+		b.setInitialContentCmd(b.setInitialContentSub, isJSONLines),
+		waitForInitialContentReady(b.setInitialContentSub))
 }
 
 func (b Bubble) Update(msg tea.Msg) (Bubble, tea.Cmd) {
@@ -104,6 +132,15 @@ func (b Bubble) Update(msg tea.Msg) (Bubble, tea.Cmd) {
 		cmd  tea.Cmd
 		cmds []tea.Cmd
 	)
+
+	if msg, ok := msg.(setPrettifiedContentMsg); ok {
+		b.highlightedJSON = msg.Content
+		b.SetContent(msg.Content.String())
+		b.loading = false
+		return b, func() tea.Msg {
+			return InputReadyMsg{}
+		}
+	}
 
 	b.viewport, cmd = b.viewport.Update(msg)
 	cmds = append(cmds, cmd)

--- a/tui/bubbles/jqplayground/commands.go
+++ b/tui/bubbles/jqplayground/commands.go
@@ -31,10 +31,6 @@ type copyQueryToClipboardMsg struct{}
 
 type copyResultsToClipboardMsg struct{}
 
-type setInputDataContentMsg struct {
-	content []byte
-}
-
 // processQueryResults iterates through the results of a gojq query on the provided JSON object
 // and appends the formatted results to the provided string builder.
 func processQueryResults(ctx context.Context, results *strings.Builder, query *gojq.Query, obj any) error {
@@ -155,14 +151,5 @@ func (b Bubble) copyQueryToClipboard() tea.Cmd {
 			}
 		}
 		return copyQueryToClipboardMsg{}
-	}
-}
-
-func (Bubble) setInputDataContentCommand(content []byte) tea.Cmd {
-
-	return func() tea.Msg {
-		return setInputDataContentMsg{
-			content: content,
-		}
 	}
 }

--- a/tui/bubbles/jqplayground/init.go
+++ b/tui/bubbles/jqplayground/init.go
@@ -1,16 +1,30 @@
 package jqplayground
 
 import (
-	"github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/noahgorstein/jqp/tui/utils"
 )
+
+// InvalidInputMsg signals that the user's data is not valid JSON or NDJSON
+type InvalidInputMsg struct{}
 
 func (b Bubble) Init() tea.Cmd {
 	var cmds []tea.Cmd
+
+	// validate input data
+	_, isJSONLines, err := utils.IsValidInput(b.inputdata.GetInputJSON())
+	if err != nil {
+		return func() tea.Msg {
+			return InvalidInputMsg{}
+		}
+	}
+
+	// initialize rest of app
+	b.isJSONLines = isJSONLines
+	cmds = append(cmds, b.queryinput.Init(), b.inputdata.Init(isJSONLines))
 	if b.queryinput.GetInputValue() != "" {
 		b.executeQuery(&cmds)
 	}
-
-	setInputDataContentCmd := b.setInputDataContentCommand(b.inputdata.GetHighlightedInputJSON())
-	cmds = append(cmds, b.queryinput.Init(), setInputDataContentCmd)
-	return tea.Batch(cmds...)
+	return tea.Sequence(cmds...)
 }

--- a/tui/bubbles/jqplayground/model.go
+++ b/tui/bubbles/jqplayground/model.go
@@ -32,10 +32,11 @@ type Bubble struct {
 	results          string
 	cancel           func()
 	theme            theme.Theme
+	ExitMessage      string
 	isJSONLines      bool
 }
 
-func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, isJSONLines bool) (Bubble, error) {
+func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme) (Bubble, error) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		return Bubble{}, err
@@ -47,7 +48,7 @@ func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, i
 
 	fs.SetInput(workingDirectory)
 
-	inputData, err := inputdata.New(inputJSON, filename, jqtheme, isJSONLines)
+	inputData, err := inputdata.New(inputJSON, filename, jqtheme)
 	if err != nil {
 		return Bubble{}, err
 	}
@@ -58,7 +59,7 @@ func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, i
 
 	b := Bubble{
 		workingDirectory: workingDirectory,
-		state:            state.Query,
+		state:            state.Loading,
 		queryinput:       queryInput,
 		inputdata:        inputData,
 		output:           output.New(jqtheme),
@@ -66,7 +67,6 @@ func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, i
 		statusbar:        sb,
 		fileselector:     fs,
 		theme:            jqtheme,
-		isJSONLines:      isJSONLines,
 	}
 	return b, nil
 }

--- a/tui/bubbles/jqplayground/update.go
+++ b/tui/bubbles/jqplayground/update.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/noahgorstein/jqp/tui/bubbles/inputdata"
 	"github.com/noahgorstein/jqp/tui/bubbles/state"
 )
 
@@ -52,8 +53,6 @@ func (b *Bubble) handleMessage(msg tea.Msg, cmds *[]tea.Cmd) {
 		b.handleWindowSizeMsg(msg)
 	case tea.KeyMsg:
 		b.handleKeyMsg(msg, cmds)
-	case setInputDataContentMsg:
-		b.handleSetInputDataContentMsg(msg)
 	case queryResultMsg:
 		b.handleQueryResultMsg(msg, cmds)
 	case writeToFileMsg:
@@ -64,11 +63,11 @@ func (b *Bubble) handleMessage(msg tea.Msg, cmds *[]tea.Cmd) {
 		b.handleCopyQueryToClipboardMsg(cmds)
 	case errorMsg:
 		b.handleErrorMsg(msg, cmds)
+	case InvalidInputMsg:
+		b.handleInvalidInput(cmds)
+	case inputdata.InputReadyMsg:
+		b.state = state.Query
 	}
-}
-
-func (b *Bubble) handleSetInputDataContentMsg(msg setInputDataContentMsg) {
-	b.inputdata.SetContent(string(msg.content))
 }
 
 func (b *Bubble) handleQueryResultMsg(msg queryResultMsg, cmds *[]tea.Cmd) {
@@ -120,6 +119,11 @@ func (b *Bubble) handleKeyMsg(msg tea.KeyMsg, cmds *[]tea.Cmd) {
 	if handler, ok := keyHandlers[msg.Type]; ok {
 		handler()
 	}
+}
+
+func (b *Bubble) handleInvalidInput(cmds *[]tea.Cmd) {
+	b.ExitMessage = "Data is not valid JSON or NDJSON"
+	*cmds = append(*cmds, tea.Quit)
 }
 
 func (b *Bubble) handleCtrlC(cmds *[]tea.Cmd) {
@@ -226,19 +230,32 @@ func (b *Bubble) setComponentBorderColors(query, input, output lipgloss.Color) {
 
 func (b *Bubble) updateComponents(msg tea.Msg, cmds *[]tea.Cmd) {
 	var cmd tea.Cmd
-	switch b.state {
-	case state.Query:
-		b.queryinput, cmd = b.queryinput.Update(msg)
-		*cmds = append(*cmds, cmd)
-	case state.Input:
-		b.inputdata, cmd = b.inputdata.Update(msg)
-		*cmds = append(*cmds, cmd)
-	case state.Output:
-		b.output, cmd = b.output.Update(msg)
-		*cmds = append(*cmds, cmd)
-	case state.Save:
-		b.fileselector, cmd = b.fileselector.Update(msg)
-		*cmds = append(*cmds, cmd)
+	dispatch := map[state.State]func(msg tea.Msg, cmds *[]tea.Cmd){
+		state.Query: func(msg tea.Msg, cmds *[]tea.Cmd) {
+			b.queryinput, cmd = b.queryinput.Update(msg)
+			*cmds = append(*cmds, cmd)
+
+		},
+		state.Input: func(msg tea.Msg, cmds *[]tea.Cmd) {
+			b.inputdata, cmd = b.inputdata.Update(msg)
+			*cmds = append(*cmds, cmd)
+		},
+		state.Output: func(msg tea.Msg, cmds *[]tea.Cmd) {
+			b.output, cmd = b.output.Update(msg)
+			*cmds = append(*cmds, cmd)
+		},
+		state.Save: func(msg tea.Msg, cmds *[]tea.Cmd) {
+			b.fileselector, cmd = b.fileselector.Update(msg)
+			*cmds = append(*cmds, cmd)
+		},
+		state.Loading: func(msg tea.Msg, cmds *[]tea.Cmd) {
+			b.inputdata, cmd = b.inputdata.Update(msg)
+			*cmds = append(*cmds, cmd)
+		},
+	}
+
+	if updateFunc, ok := dispatch[b.state]; ok {
+		updateFunc(msg, cmds)
 	}
 
 	b.statusbar, cmd = b.statusbar.Update(msg)
@@ -246,4 +263,5 @@ func (b *Bubble) updateComponents(msg tea.Msg, cmds *[]tea.Cmd) {
 
 	b.help, cmd = b.help.Update(msg)
 	*cmds = append(*cmds, cmd)
+
 }

--- a/tui/bubbles/jqplayground/update.go
+++ b/tui/bubbles/jqplayground/update.go
@@ -65,7 +65,7 @@ func (b *Bubble) handleMessage(msg tea.Msg, cmds *[]tea.Cmd) {
 		b.handleErrorMsg(msg, cmds)
 	case InvalidInputMsg:
 		b.handleInvalidInput(cmds)
-	case inputdata.InputReadyMsg:
+	case inputdata.ReadyMsg:
 		b.state = state.Query
 	}
 }

--- a/tui/bubbles/state/state.go
+++ b/tui/bubbles/state/state.go
@@ -8,4 +8,5 @@ const (
 	Input
 	Output
 	Save
+	Loading
 )

--- a/tui/utils/json.go
+++ b/tui/utils/json.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -14,6 +15,19 @@ import (
 )
 
 const FourSpaces = "    "
+
+// IsValidInput checks the validity of input data as JSON or JSON lines.
+// It takes a byte slice 'data' and returns two boolean values indicating
+// whether the data is valid JSON and valid JSON lines, along with an error
+// if the data is not valid in either format.
+func IsValidInput(data []byte) (isValidJSON bool, isValidJSONLines bool, err error) {
+	isValidJSON = IsValidJSON(data)
+	isValidJSONLines = IsValidJSONLines(data)
+	if !isValidJSON && !isValidJSONLines {
+		return false, false, errors.New("Data is not valid JSON or NDJSON")
+	}
+	return isValidJSON, isValidJSONLines, nil
+}
 
 func highlightJSON(w io.Writer, source string, style *chroma.Style) error {
 	l := lexers.Get("json")


### PR DESCRIPTION
mostly applies for larger inputs (>1-2MB). It turns out prettifying the input data (syntax highlighting with Chroma) can be a bottleneck in jqp. The changes here allow for the prettification of input data to be performed asynchronously, reducing the likelihood of blocking the main thread, especially with large inputs. 


See the experience using jqp on a 9MB file before and after this change. You can see something a little odd happens with the view here as a result of components not being updated (and thus resized) as a result of the syntax highlighting blocking the main event loop in Bubbletea.

before:

![before](https://github.com/noahgorstein/jqp/assets/23270779/7998f702-7ff6-457e-95dd-3d3643f751fe)


after:

![after](https://github.com/noahgorstein/jqp/assets/23270779/b54f88ad-720b-4602-a2a8-476e169c54f6)


> [!NOTE]
> a better implementation is probably incrementally highlighting whatever data is visible in the viewports but a little too much to bite of now. 
