### PR TITLE
fix: dynamically increase buffer size to handle processing large JSON lines

### DIFF
--- a/tui/utils/json.go
+++ b/tui/utils/json.go
@@ -65,7 +65,7 @@ func IsValidJSON(input []byte) error {
 }
 
 func IsValidJSONLines(input []byte) error {
-	maxBufferSize := 10 * 1024 * 1024 // 10MB
+	maxBufferSize := 100 * 1024 * 1024 // 100MB
 	err := ScanLinesWithDynamicBufferSize(input, maxBufferSize, IsValidJSON)
 	if err != nil {
 		return err

--- a/tui/utils/scan.go
+++ b/tui/utils/scan.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// ScanLinesWithDynamicBufferSize scans the input byte slice line by line, using a dynamically
+// increasing buffer size. It starts with an initial buffer size of 64KB and doubles the buffer
+// size each time a line exceeds the current buffer size, up to the specified maximum buffer size.
+//
+// If a line exceeds the maximum buffer size, it returns an error.
+//
+// The processLine function is called for each line and should return an error if processing fails.
+//
+// The function returns an error if the input exceeds the maximum buffer size or if any other
+// error occurs during line processing. It returns nil if all lines are processed successfully.
+func ScanLinesWithDynamicBufferSize(input []byte, maxBufferSize int, processLine func([]byte) error) error {
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	initialBufferSize := 64 * 1024 // 64KB initial buffer size
+
+	for bufferSize := initialBufferSize; bufferSize <= maxBufferSize; bufferSize *= 2 {
+		if err := scanWithBufferSize(scanner, bufferSize, maxBufferSize, processLine); err != nil {
+			if errors.Is(err, bufio.ErrTooLong) {
+				// Buffer size is too small, retry with a larger buffer
+				continue
+			}
+			return err
+		}
+		// All lines are processed successfully
+		return nil
+	}
+
+	// Input exceeds maximum buffer size
+	return fmt.Errorf("input exceeds maximum buffer size of %d bytes", maxBufferSize)
+}
+
+func scanWithBufferSize(scanner *bufio.Scanner, bufferSize, maxBufferSize int, processLine func([]byte) error) error {
+	scanner.Buffer(make([]byte, bufferSize), maxBufferSize)
+
+	for scanner.Scan() {
+		if err := processLine(scanner.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return scanner.Err()
+}


### PR DESCRIPTION
Per the bufio docs: https://pkg.go.dev/bufio#Scanner.Buffer:

> Buffer sets the initial buffer to use when scanning and the maximum size of buffer that may be allocated during scanning. The maximum token size must be less than the larger of max and cap(buf). If max <= cap(buf), [Scanner.Scan](https://pkg.go.dev/bufio#Scanner.Scan) will use this buffer only and do no allocation.
>
>By default, [Scanner.Scan](https://pkg.go.dev/bufio#Scanner.Scan) uses an internal buffer and sets the maximum token size to [MaxScanTokenSize](https://pkg.go.dev/bufio#MaxScanTokenSize).
> ...

This became problematic for us when I introduced code to handle NDJSON (JSON lines) as input. If one of the lines was greater than `64KB` (`MaxScanTokenSize`) or if the JSON was minified such that it was all on one line, we would run into an issue scanning each line because the maximum buffer used for reading would not have enough capacity. 

This PR will still attempt to use a 64KB buffer to process each line but will keep retrying if the buffer is not large enough. Each retry will double the buffer size. The max buffer size is 100MB which is somewhat arbitrarily large but jqp will fail to be performant at this scale anyway due to syntax highlighting and writing large input/output to viewports so will keep it there for now.