### PR TITLE
Fix unmarshalling long numbers

### DIFF
--- a/tui/bubbles/jqplayground/commands.go
+++ b/tui/bubbles/jqplayground/commands.go
@@ -1,6 +1,7 @@
 package jqplayground
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -46,15 +47,19 @@ func processQueryResults(ctx context.Context, results *strings.Builder, query *g
 		if r, err := gojq.Marshal(v); err == nil {
 			results.WriteString(fmt.Sprintf("%s\n", string(r)))
 		}
+
 	}
 	return nil
 }
 
 func processJSONWithQuery(ctx context.Context, results *strings.Builder, query *gojq.Query, data []byte) error {
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
 	var obj any
-	if err := json.Unmarshal(data, &obj); err != nil {
+	if err := d.Decode(&obj); err != nil {
 		return err
 	}
+
 	err := processQueryResults(ctx, results, query, obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hello,

Thanks for this TUI, it's great. 
While using it I encountered a small issue with long numbers.
Ex:
````
{"id": -255265317443125267}  
````
Result with query "." : 
`````
{ "id": -255265317443125280}
`````

Json unmarshalling unmarshalls json numbers in float64 which is confusing in the output.

This small change fixes this issue.
