### PR TITLE
Remove Homebrew tap publishing & update docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,18 +30,3 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-brews:
-  - homepage: https://github.com/noahgorstein/jqp
-    description: "a TUI playground to experiment and play with jq"
-    directory: Formula
-    repository:
-      owner: noahgorstein
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    license: "MIT"
-    install: |
-      bin.install "jqp"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This application utilizes [itchyny's](https://github.com/itchyny) implementation
 ### homebrew
 
 ```bash
-brew install noahgorstein/tap/jqp
+brew install jqp
 ```
 
 ### macports


### PR DESCRIPTION
`jqp` is now available in Homebrew Core, so publishing a separate tap
formula is no longer necessary:
https://github.com/Homebrew/homebrew-core/blob/main/Formula/j/jqp.rb

## Changes in this PR:

- remove the Homebrew `brews` section from `.goreleaser.yaml`
- update README to recommend `brew install jqp`

Once https://github.com/noahgorstein/homebrew-tap/pull/1 is merged, installs using the old tap will automatically migrate to Homebrew Core. I think it makes sense to stop publishing the tap and update the documentation accordingly.