### PR TITLE
feat: add keybinding (Ctrl+t) to toggle showing/hiding the input data

### DIFF
--- a/tui/bubbles/help/keys.go
+++ b/tui/bubbles/help/keys.go
@@ -3,14 +3,15 @@ package help
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	section   key.Binding
-	back      key.Binding
-	submit    key.Binding
-	abort     key.Binding
-	navigate  key.Binding
-	page      key.Binding
-	save      key.Binding
-	copyQuery key.Binding
+	section     key.Binding
+	back        key.Binding
+	submit      key.Binding
+	abort       key.Binding
+	navigate    key.Binding
+	page        key.Binding
+	save        key.Binding
+	copyQuery   key.Binding
+	toggleInput key.Binding
 }
 
 var keys = keyMap{
@@ -38,4 +39,7 @@ var keys = keyMap{
 	copyQuery: key.NewBinding(
 		key.WithKeys("ctrl+y"),
 		key.WithHelp("ctrl+y", "copy query")),
+	toggleInput: key.NewBinding(
+		key.WithKeys("ctrl+t"),
+		key.WithHelp("ctrl+t", "toggle input panel")),
 }

--- a/tui/bubbles/jqplayground/model.go
+++ b/tui/bubbles/jqplayground/model.go
@@ -34,6 +34,7 @@ type Bubble struct {
 	theme            theme.Theme
 	ExitMessage      string
 	isJSONLines      bool
+	showInputPanel   bool
 }
 
 func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme) (Bubble, error) {
@@ -67,6 +68,7 @@ func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme) (
 		statusbar:        sb,
 		fileselector:     fs,
 		theme:            jqtheme,
+		showInputPanel:   true,
 	}
 	return b, nil
 }

--- a/tui/bubbles/jqplayground/update.go
+++ b/tui/bubbles/jqplayground/update.go
@@ -49,9 +49,6 @@ func (b *Bubble) resizeBubbles() {
 	} else {
 		b.output.SetSize(b.width, height)
 	}
-
-	// Re-render the output content to reflow text for the new dimensions
-	b.output.SetContent(b.output.GetContent())
 }
 
 //nolint:revive // don't see a more elegant way to reduce complexity here since types can't be keys in a map
@@ -116,6 +113,8 @@ func (b *Bubble) handleWindowSizeMsg(msg tea.WindowSizeMsg) {
 	b.width = msg.Width
 	b.height = msg.Height
 	b.resizeBubbles()
+	// Re-render the output content to reflow text for the new window dimensions
+	b.output.SetContent(b.output.GetContent())
 }
 
 func (b *Bubble) handleKeyMsg(msg tea.KeyMsg, cmds *[]tea.Cmd) {
@@ -253,6 +252,8 @@ func (b *Bubble) handleCtrlT() {
 	}
 	b.help.SetInputPanelVisibility(b.showInputPanel)
 	b.resizeBubbles()
+	// Re-render the output content to reflow text for the new panel width
+	b.output.SetContent(b.output.GetContent())
 }
 
 func (b *Bubble) updateState(prevState state.State, cmds *[]tea.Cmd) {

--- a/tui/bubbles/jqplayground/update.go
+++ b/tui/bubbles/jqplayground/update.go
@@ -42,8 +42,16 @@ func (b *Bubble) resizeBubbles() {
 	} else {
 		height -= totalHeight(b.help, b.queryinput, b.statusbar)
 	}
-	b.inputdata.SetSize(b.width/2, height)
-	b.output.SetSize(b.width/2, height)
+
+	if b.showInputPanel {
+		b.inputdata.SetSize(b.width/2, height)
+		b.output.SetSize(b.width/2, height)
+	} else {
+		b.output.SetSize(b.width, height)
+	}
+
+	// Re-render the output content to reflow text for the new dimensions
+	b.output.SetContent(b.output.GetContent())
 }
 
 //nolint:revive // don't see a more elegant way to reduce complexity here since types can't be keys in a map
@@ -119,6 +127,7 @@ func (b *Bubble) handleKeyMsg(msg tea.KeyMsg, cmds *[]tea.Cmd) {
 		tea.KeyEnter:    func() { b.handleEnter(cmds) },
 		tea.KeyCtrlS:    b.handleCtrlS,
 		tea.KeyCtrlY:    func() { b.handleCtrlY(cmds) },
+		tea.KeyCtrlT:    b.handleCtrlT,
 	}
 	if handler, ok := keyHandlers[msg.Type]; ok {
 		handler()
@@ -144,15 +153,30 @@ func (b *Bubble) handleCtrlC(cmds *[]tea.Cmd) {
 //nolint:revive // switch statement complexity is acceptable here
 func (b *Bubble) handleTab() {
 	if b.state != state.Save {
-		switch b.state {
-		case state.Query:
-			b.state = state.Input
-		case state.Input:
-			b.state = state.Output
-		case state.Output:
-			b.state = state.Query
-		default:
-			// No state change for unknown states
+		if b.showInputPanel {
+			switch b.state {
+			case state.Query:
+				b.state = state.Input
+			case state.Input:
+				b.state = state.Output
+			case state.Output:
+				b.state = state.Query
+			default:
+				// No state change for unknown states
+			}
+		} else {
+			// When input panel is hidden, only toggle between Query and Output
+			switch b.state {
+			case state.Query:
+				b.state = state.Output
+			case state.Output:
+				b.state = state.Query
+			case state.Input:
+				// If somehow we're in Input state with panel hidden, go to Output
+				b.state = state.Output
+			default:
+				// No state change for unknown states
+			}
 		}
 	}
 }
@@ -160,15 +184,30 @@ func (b *Bubble) handleTab() {
 //nolint:revive // switch statement complexity is acceptable here
 func (b *Bubble) handleShiftTab() {
 	if b.state != state.Save {
-		switch b.state {
-		case state.Query:
-			b.state = state.Output
-		case state.Input:
-			b.state = state.Query
-		case state.Output:
-			b.state = state.Input
-		default:
-			// No state change for unknown states
+		if b.showInputPanel {
+			switch b.state {
+			case state.Query:
+				b.state = state.Output
+			case state.Input:
+				b.state = state.Query
+			case state.Output:
+				b.state = state.Input
+			default:
+				// No state change for unknown states
+			}
+		} else {
+			// When input panel is hidden, only toggle between Query and Output
+			switch b.state {
+			case state.Query:
+				b.state = state.Output
+			case state.Output:
+				b.state = state.Query
+			case state.Input:
+				// If somehow we're in Input state with panel hidden, go to Query
+				b.state = state.Query
+			default:
+				// No state change for unknown states
+			}
 		}
 	}
 }
@@ -204,6 +243,16 @@ func (b *Bubble) handleCtrlY(cmds *[]tea.Cmd) {
 	if b.state != state.Save {
 		*cmds = append(*cmds, b.copyQueryToClipboard())
 	}
+}
+
+func (b *Bubble) handleCtrlT() {
+	b.showInputPanel = !b.showInputPanel
+	// If we're hiding the input panel while in Input state, switch to Query state
+	if !b.showInputPanel && b.state == state.Input {
+		b.state = state.Query
+	}
+	b.help.SetInputPanelVisibility(b.showInputPanel)
+	b.resizeBubbles()
 }
 
 func (b *Bubble) updateState(prevState state.State, cmds *[]tea.Cmd) {

--- a/tui/bubbles/jqplayground/view.go
+++ b/tui/bubbles/jqplayground/view.go
@@ -7,11 +7,17 @@ import (
 )
 
 func (b Bubble) View() string {
-	inputoutput := []string{b.inputdata.View()}
-	if b.width%2 != 0 {
-		inputoutput = append(inputoutput, " ")
+	var inputoutput []string
+
+	if b.showInputPanel {
+		inputoutput = []string{b.inputdata.View()}
+		if b.width%2 != 0 {
+			inputoutput = append(inputoutput, " ")
+		}
+		inputoutput = append(inputoutput, b.output.View())
+	} else {
+		inputoutput = []string{b.output.View()}
 	}
-	inputoutput = append(inputoutput, b.output.View())
 
 	if b.state == state.Save {
 		return lipgloss.JoinVertical(


### PR DESCRIPTION
- adds a new keybinding (Ctrl+t) to toggle showing/hiding the input data panel. Useful if you know what your data looks like and want to see the filtered output on larger panel.
- addresses #155 

Demo:


https://github.com/user-attachments/assets/2f1b9ee4-4f8e-4e47-8de3-5a983515aec2

