### PR TITLE
feat: added '--show-input-panel' CLI argument

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ You can provide the input JSON or NDJSON either through a file or via standard i
 			if err != nil {
 				return err
 			}
-			bubble, err := jqplayground.New(stdin, "STDIN", query, jqtheme)
+			bubble, err := jqplayground.New(stdin, "STDIN", query, jqtheme, flags.showInputPanel)
 			if err != nil {
 				return err
 			}
@@ -102,7 +102,7 @@ You can provide the input JSON or NDJSON either through a file or via standard i
 			return err
 		}
 
-		bubble, err := jqplayground.New(data, fi.Name(), query, jqtheme)
+		bubble, err := jqplayground.New(data, fi.Name(), query, jqtheme, flags.showInputPanel)
 		if err != nil {
 			return err
 		}
@@ -154,15 +154,18 @@ func initConfig() {
 
 var flags struct {
 	filepath, theme string
+	showInputPanel  bool
 }
 
 var flagsName = struct {
-	file, fileShort, theme, themeShort string
+	file, fileShort, theme, themeShort, showInputPanel, showInputPanelShort string
 }{
-	file:       "file",
-	fileShort:  "f",
-	theme:      "theme",
-	themeShort: "t",
+	file:                "file",
+	fileShort:           "f",
+	theme:               "theme",
+	themeShort:          "t",
+	showInputPanel:      "show-input-panel",
+	showInputPanelShort: "i",
 }
 
 var configKeysName = struct {
@@ -193,6 +196,8 @@ func Execute() error {
 		flagsName.theme,
 		flagsName.themeShort,
 		"", "jqp theme")
+
+	rootCmd.Flags().BoolVarP(&flags.showInputPanel, flagsName.showInputPanel, flagsName.showInputPanelShort, true, "show input panel")
 
 	return rootCmd.Execute()
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,12 +16,13 @@ description: |
     jqp [query] [flags]
 
   Flags:
-    --config string   path to config file (default is $HOME/.jqp.yaml)
-    -f, --file string     path to the input JSON file
-    -h, --help            help for jqp
-    -t, --theme string    jqp theme
-    -v, --version         version for jqp
-    
+    --config string      path to config file (default is $HOME/.jqp.yaml)
+    -f, --file string        path to the input JSON file
+    -h, --help               help for jqp
+    -i, --show-input-panel   show input panel (default true)
+    -t, --theme string       jqp theme
+    -v, --version            version for jqp
+
 license: MIT
 issues: https://github.com/kz6fittycent/jqp
 contact: https://github.com/kz6fittycent/jqp

--- a/tui/bubbles/help/help.go
+++ b/tui/bubbles/help/help.go
@@ -17,7 +17,7 @@ type Bubble struct {
 	showInputPanel bool
 }
 
-func New(jqtheme theme.Theme) Bubble {
+func New(jqtheme theme.Theme, showInputPanel bool) Bubble {
 	styles := DefaultStyles()
 	model := help.New()
 	model.Styles.ShortKey = styles.helpKeyStyle.Foreground(jqtheme.Primary)
@@ -29,7 +29,7 @@ func New(jqtheme theme.Theme) Bubble {
 		Styles:         styles,
 		help:           model,
 		keys:           keys,
-		showInputPanel: true, // Default to showing input panel
+		showInputPanel: showInputPanel,
 	}
 }
 

--- a/tui/bubbles/jqplayground/model.go
+++ b/tui/bubbles/jqplayground/model.go
@@ -37,7 +37,7 @@ type Bubble struct {
 	showInputPanel   bool
 }
 
-func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme) (Bubble, error) {
+func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme, showInputPanel bool) (Bubble, error) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		return Bubble{}, err
@@ -64,11 +64,11 @@ func New(inputJSON []byte, filename string, query string, jqtheme theme.Theme) (
 		queryinput:       queryInput,
 		inputdata:        inputData,
 		output:           output.New(jqtheme),
-		help:             help.New(jqtheme),
+		help:             help.New(jqtheme, showInputPanel),
 		statusbar:        sb,
 		fileselector:     fs,
 		theme:            jqtheme,
-		showInputPanel:   true,
+		showInputPanel:   showInputPanel,
 	}
 	return b, nil
 }


### PR DESCRIPTION
In the recent release was added the [ability to hide/show the input panel](https://github.com/noahgorstein/jqp/pull/182), which I think is a great idea.

However, I use `jqp` in a few of my scripts, and I'd like to be able to hide the input panel via CLI argument, so that I don't have to hit `Ctrl+t` every time.